### PR TITLE
Feature - Automatic gas/mineral balance

### DIFF
--- a/Bot.Tests/CircularQueueTests.cs
+++ b/Bot.Tests/CircularQueueTests.cs
@@ -1,0 +1,112 @@
+﻿namespace Bot.Tests;
+
+public class CircularQueueTests {
+    [Fact]
+    public void GivenEmptyQueue_WhenEnqueue_ThenAddsToEndOfQueue() {
+        // Arrange
+        const int numberOfItemsToQueue = 20;
+        const int queueSize = 5;
+        var circularQueue = new CircularQueue<int>(queueSize);
+
+        // Act
+        for (int i = 0; i < numberOfItemsToQueue; i++) {
+            var valueToAdd = i + 1;
+            circularQueue.Enqueue(valueToAdd);
+
+            // Assert
+            Assert.Equal(valueToAdd, circularQueue[i]);
+        }
+    }
+
+    [Fact]
+    public void GivenEmpty_WhenEnqueue_ThenReturnsQueueSize() {
+        // Arrange
+        const int numberOfItemsToQueue = 20;
+        const int queueSize = 5;
+        var circularQueue = new CircularQueue<int>(queueSize);
+
+        // Act
+        for (int i = 0; i < numberOfItemsToQueue; i++) {
+            var queueLength = circularQueue.Enqueue(i);
+
+            // Assert
+            Assert.Equal(circularQueue.Length, queueLength);
+        }
+    }
+
+    [Fact]
+    public void GivenEmptyQueue_WhenDequeue_ThenThrows() {
+        // Arrange
+        var circularQueue = new CircularQueue<int>(5);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => circularQueue.Dequeue());
+    }
+
+    [Fact]
+    public void GivenPartiallyFilledQueue_WhenDequeueTooManyTime_ThenThrows() {
+        // Arrange
+        const int queueSize = 5;
+        var circularQueue = new CircularQueue<int>(queueSize);
+
+        // Act
+        for (var i = 0; i < queueSize - 1; i++) {
+            var valueToAdd = i + 1;
+            circularQueue.Enqueue(valueToAdd);
+        }
+
+        var numberOfElementsToRemove = circularQueue.Length;
+        for (var i = 0; i < numberOfElementsToRemove; i++) {
+            circularQueue.Dequeue();
+        }
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(() => circularQueue.Dequeue());
+    }
+
+    [Fact]
+    public void GivenPartiallyFilledQueue_WhenDequeue_ThenDequeuesInInsertionOrder() {
+        // Arrange
+        const int numberOfItemsToQueue = 4;
+        const int queueSize = 5;
+        var circularQueue = new CircularQueue<int>(queueSize);
+
+        // Act
+        for (var i = 0; i < numberOfItemsToQueue; i++) {
+            var valueToAdd = i + 1;
+            circularQueue.Enqueue(valueToAdd);
+        }
+
+        var numberOfElementsToRemove = circularQueue.Length;
+        for (var i = 0; i < numberOfElementsToRemove; i++) {
+            var expectedValue = i + 1;
+            var actualValue = circularQueue.Dequeue();
+
+            // Assert
+            Assert.Equal(expectedValue, actualValue);
+        }
+    }
+
+    [Fact]
+    public void GivenOverflownQueue_WhenDequeue_ThenDequeuesLastInsertedItemsInInsertionOrder() {
+        // Arrange
+        const int numberOfItemsToQueue = 20;
+        const int queueSize = 5;
+        var circularQueue = new CircularQueue<int>(queueSize);
+
+        // Act
+        for (var i = 0; i < numberOfItemsToQueue; i++) {
+            var valueToAdd = i + 1;
+            circularQueue.Enqueue(valueToAdd);
+        }
+
+        var numberOfElementsToRemove = circularQueue.Length;
+        for (var i = 0; i < numberOfElementsToRemove; i++) {
+            var expectedValue = numberOfItemsToQueue - (queueSize - i) + 1;
+            var actualValue = circularQueue.Dequeue();
+
+            // Assert
+            Assert.Equal(expectedValue, actualValue);
+        }
+    }
+}

--- a/Bot.Tests/ResponseGameObservationUtils.cs
+++ b/Bot.Tests/ResponseGameObservationUtils.cs
@@ -36,6 +36,14 @@ public static class ResponseGameObservationUtils {
                     },
                     Player = new PlayerRaw(),
                 },
+                Score = new Score
+                {
+                    ScoreDetails = new ScoreDetails
+                    {
+                        CollectionRateMinerals = 0,
+                        CollectionRateVespene = 0,
+                    }
+                }
             }
         };
 

--- a/Bot/Builds/BuildOrders/TestGasMining.cs
+++ b/Bot/Builds/BuildOrders/TestGasMining.cs
@@ -10,12 +10,23 @@ public class TestGasMining : IBuildOrder {
     public TestGasMining() {
         BuildRequests = new List<BuildRequest>
         {
-            new QuantityBuildRequest(BuildType.Build, Units.Extractor),
-            new QuantityBuildRequest(BuildType.Train, Units.Overlord, atSupply: 13),
-            new QuantityBuildRequest(BuildType.Build, Units.Extractor),
-            new QuantityBuildRequest(BuildType.Train, Units.Overlord, atSupply: 19),
-            new QuantityBuildRequest(BuildType.Train, Units.Overlord, atSupply: 19),
+            new QuantityBuildRequest(BuildType.Train, Units.Drone,     atSupply: 12),
+            new QuantityBuildRequest(BuildType.Train, Units.Overlord,  atSupply: 13),
+            new TargetBuildRequest  (BuildType.Train, Units.Drone,     atSupply: 13, targetQuantity: 19),
+            new QuantityBuildRequest(BuildType.Train, Units.Overlord,  atSupply: 19),
+            new TargetBuildRequest  (BuildType.Train, Units.Drone,     atSupply: 19, targetQuantity: 27),
+            new TargetBuildRequest  (BuildType.Build, Units.Extractor, atSupply: 24, targetQuantity: 2),
+            new QuantityBuildRequest(BuildType.Train, Units.Overlord,  atSupply: 27),
+            new TargetBuildRequest  (BuildType.Train, Units.Drone,     atSupply: 27, targetQuantity: 30),
+
+            // Prevent anyone else from building anything else
+            new QuantityBuildRequest(BuildType.Train, Units.Zergling, atSupply: 30),
         };
+
+        foreach (var buildRequest in BuildRequests) {
+            buildRequest.Priority = BuildRequestPriority.VeryHigh;
+            buildRequest.BlockCondition = BuildBlockCondition.All;
+        }
     }
 
     public void PruneRequests() {}

--- a/Bot/Builds/BuildOrders/TestMineralSaturatedMining.cs
+++ b/Bot/Builds/BuildOrders/TestMineralSaturatedMining.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using Bot.GameData;
+using Bot.GameSense.EnemyStrategyTracking;
+
+namespace Bot.Builds.BuildOrders;
+
+public class TestMineralSaturatedMining : IBuildOrder {
+    public IReadOnlyCollection<BuildRequest> BuildRequests { get; }
+
+    public TestMineralSaturatedMining() {
+        BuildRequests = new List<BuildRequest>
+        {
+            new QuantityBuildRequest(BuildType.Train, Units.Drone,    atSupply: 12),
+            new QuantityBuildRequest(BuildType.Train, Units.Overlord, atSupply: 13),
+            new TargetBuildRequest  (BuildType.Train, Units.Drone,    atSupply: 13, targetQuantity: 19),
+            new QuantityBuildRequest(BuildType.Train, Units.Overlord, atSupply: 19),
+            new TargetBuildRequest  (BuildType.Train, Units.Drone,    atSupply: 19, targetQuantity: 24),
+
+            // Prevent anyone else from building anything else
+            new QuantityBuildRequest(BuildType.Train, Units.Zergling, atSupply: 24),
+        };
+
+        foreach (var buildRequest in BuildRequests) {
+            buildRequest.Priority = BuildRequestPriority.VeryHigh;
+            buildRequest.BlockCondition = BuildBlockCondition.All;
+        }
+    }
+
+    public void PruneRequests() {}
+
+    public void ReactTo(EnemyStrategy newEnemyStrategy) {}
+}

--- a/Bot/Builds/BuildOrders/TestMineralSpeedMining.cs
+++ b/Bot/Builds/BuildOrders/TestMineralSpeedMining.cs
@@ -4,16 +4,24 @@ using Bot.GameSense.EnemyStrategyTracking;
 
 namespace Bot.Builds.BuildOrders;
 
-public class TestSpeedMining : IBuildOrder {
+public class TestMineralSpeedMining : IBuildOrder {
     public IReadOnlyCollection<BuildRequest> BuildRequests { get; }
 
-    public TestSpeedMining() {
+    public TestMineralSpeedMining() {
         BuildRequests = new List<BuildRequest>
         {
             new QuantityBuildRequest(BuildType.Train, Units.Drone,    atSupply: 12),
             new QuantityBuildRequest(BuildType.Train, Units.Overlord, atSupply: 13),
             new TargetBuildRequest  (BuildType.Train, Units.Drone,    atSupply: 13, targetQuantity: 16),
+
+            // Prevent anyone else from building anything else
+            new QuantityBuildRequest(BuildType.Train, Units.Zergling, atSupply: 16),
         };
+
+        foreach (var buildRequest in BuildRequests) {
+            buildRequest.Priority = BuildRequestPriority.VeryHigh;
+            buildRequest.BlockCondition = BuildBlockCondition.All;
+        }
     }
 
     public void PruneRequests() {}

--- a/Bot/Builds/BuildOrders/TwoBasesRoach.cs
+++ b/Bot/Builds/BuildOrders/TwoBasesRoach.cs
@@ -36,12 +36,6 @@ public class TwoBasesRoach : IBuildOrder {
             new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 50, targetQuantity: 3),
             new TargetBuildRequest  (BuildType.Research,    Upgrades.TunnelingClaws,           atSupply: 50, targetQuantity: 1),
             new TargetBuildRequest  (BuildType.Research,    Upgrades.GlialReconstitution,      atSupply: 50, targetQuantity: 1),
-            // TODO GD The build requests are sorted by supply. Because of this, the transition logic works, but if it changes, maybe it'll break
-            // By works I mean they push the upgrades at the end, but they'll still be before the below extractors
-            // TODO GD We should be smarter about gas
-            new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 125, targetQuantity: 4),
-            new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 165, targetQuantity: 5),
-            new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 190, targetQuantity: 6),
         };
 
         foreach (var buildRequest in _buildRequests) {

--- a/Bot/CircularQueue.cs
+++ b/Bot/CircularQueue.cs
@@ -7,8 +7,8 @@ namespace Bot;
 public class CircularQueue<T> : IEnumerable<T> {
     private readonly T[] _queue;
 
-    private int _startIndex = 0;
-    private int _endIndex = 0;
+    private int _dequeueIndex = 0;
+    private int _enqueueIndex = 0;
 
     public int Length { get; private set; } = 0;
 
@@ -21,32 +21,46 @@ public class CircularQueue<T> : IEnumerable<T> {
             throw new InvalidOperationException("Cannot dequeue when the queue is empty.");
         }
 
-        var value = _queue[_startIndex];
+        var value = _queue[_dequeueIndex];
 
-        _queue[_startIndex] = default;
-        _startIndex = CircularIncrement(_startIndex);
+        _queue[_dequeueIndex] = default;
+        _dequeueIndex = CircularIncrement(_dequeueIndex);
         Length--;
 
         return value;
     }
 
     public int Enqueue(T value) {
-        if (Length == _queue.Length && _endIndex == _startIndex) {
-            _startIndex = CircularIncrement(_startIndex);
+        if (Length == _queue.Length && _enqueueIndex == _dequeueIndex) {
+            _dequeueIndex = CircularIncrement(_dequeueIndex);
         }
 
-        _queue[_endIndex] = value;
-        _endIndex = CircularIncrement(_endIndex);
+        _queue[_enqueueIndex] = value;
+        _enqueueIndex = CircularIncrement(_enqueueIndex);
         Length = Math.Min(Length + 1, _queue.Length);
 
         return Length;
     }
 
-    public T this[int index] => _queue[index % _queue.Length];
+    public void Clear() {
+        Length = 0;
+        _dequeueIndex = 0;
+        _enqueueIndex = 0;
+    }
+
+    public T this[int index] {
+        get {
+            if (index >= Length) {
+                throw new IndexOutOfRangeException($"Trying to access element at index {index} in a queue of length {Length}");
+            }
+
+            return _queue[(_dequeueIndex + index) % _queue.Length];
+        }
+    }
 
     public IEnumerator<T> GetEnumerator() {
-        for (var i = 0; i < Length; i++) {
-            yield return _queue[_startIndex + i];
+        for (var index = 0; index < Length; index++) {
+            yield return this[index];
         }
     }
 

--- a/Bot/CircularQueue.cs
+++ b/Bot/CircularQueue.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bot;
+
+public class CircularQueue<T> : IEnumerable<T> {
+    private readonly T[] _queue;
+
+    private int _startIndex = 0;
+    private int _endIndex = 0;
+
+    public int Length { get; private set; } = 0;
+
+    public CircularQueue(int queueSize) {
+        _queue = new T[queueSize];
+    }
+
+    public T Dequeue() {
+        if (Length == 0) {
+            throw new InvalidOperationException("Cannot dequeue when the queue is empty.");
+        }
+
+        var value = _queue[_startIndex];
+
+        _queue[_startIndex] = default;
+        _startIndex = CircularIncrement(_startIndex);
+        Length--;
+
+        return value;
+    }
+
+    public int Enqueue(T value) {
+        if (Length == _queue.Length && _endIndex == _startIndex) {
+            _startIndex = CircularIncrement(_startIndex);
+        }
+
+        _queue[_endIndex] = value;
+        _endIndex = CircularIncrement(_endIndex);
+        Length = Math.Min(Length + 1, _queue.Length);
+
+        return Length;
+    }
+
+    public T this[int index] => _queue[index % _queue.Length];
+
+    public IEnumerator<T> GetEnumerator() {
+        for (var i = 0; i < Length; i++) {
+            yield return _queue[_startIndex + i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    private int CircularIncrement(int value) {
+        return (value + 1) % _queue.Length;
+    }
+}

--- a/Bot/Controller.cs
+++ b/Bot/Controller.cs
@@ -43,15 +43,16 @@ public static class Controller {
 
     public static HashSet<uint> ResearchedUpgrades { get; private set; }
 
+    // TODO GD I'm sure we could figure out the dependency graph automatically
     private static List<INeedUpdating> ThoseWhoNeedUpdating => new List<INeedUpdating>
     {
-        IncomeTracker.Instance,         // Depends on nothing
         ChatTracker.Instance,           // Depends on nothing
         VisibilityTracker.Instance,     // Depends on nothing
 
         UnitsTracker.Instance,          // Depends on VisibilityTracker
         DebuggingFlagsTracker.Instance, // Depends on ChatTracker
 
+        IncomeTracker.Instance,         // Depends on UnitsTracker
         MapAnalyzer.Instance,           // Depends on UnitsTracker and VisibilityTracker
 
         CreepTracker.Instance,          // Depends on VisibilityTracker and MapAnalyzer

--- a/Bot/Controller.cs
+++ b/Bot/Controller.cs
@@ -355,7 +355,7 @@ public static class Controller {
                 .MaxBy(gas => (gas.Supervisor as TownHallSupervisor)!.WorkerCount); // This is not cute nor clean, but it is efficient and we like that
 
             if (availableGas == null) {
-                Logger.Warning("(Controller) No available gasses for extractor");
+                Logger.Debug("(Controller) No available gasses for extractor");
                 return BuildRequestResult.NoSuitableLocation;
             }
 

--- a/Bot/Controller.cs
+++ b/Bot/Controller.cs
@@ -45,6 +45,7 @@ public static class Controller {
 
     private static List<INeedUpdating> ThoseWhoNeedUpdating => new List<INeedUpdating>
     {
+        IncomeTracker.Instance,         // Depends on nothing
         ChatTracker.Instance,           // Depends on nothing
         VisibilityTracker.Instance,     // Depends on nothing
 

--- a/Bot/Debugging/BotDebugger.cs
+++ b/Bot/Debugging/BotDebugger.cs
@@ -24,6 +24,7 @@ public class BotDebugger {
         DebugEnemyDetectors();
         DebugUnwalkableAreas();
         DebugIncomeRate();
+        DebugFutureSpending();
         DebugEnemyGhostUnits();
         DebugKnownEnemyUnits();
         DebugMatchupData();
@@ -109,7 +110,7 @@ public class BotDebugger {
         Program.GraphicalDebugger.AddTextGroup(new[]
         {
             "Resource income rates - past 30s",
-        }, virtualPos: new Point { X = 0.315f, Y = 0.715f });
+        }, virtualPos: new Point { X = 0.315f, Y = 0.700f });
 
         var activeMiningModules = Controller.GetUnits(UnitsTracker.OwnedUnits, Units.Drone)
             .Select(UnitModule.Get<MiningModule>)
@@ -123,16 +124,34 @@ public class BotDebugger {
             $"Max: {IncomeTracker.MaxMineralsCollectionRate, 9:F0}",
             $"Average: {IncomeTracker.AverageMineralsCollectionRate, 5:F0}",
             $"Current: {IncomeTracker.CurrentMineralsCollectionRate, 5:F0}",
-        }, virtualPos: new Point { X = 0.315f, Y = 0.740f });
+            $"Expected: {IncomeTracker.ExpectedMineralsCollectionRate, 4:F0}",
+        }, virtualPos: new Point { X = 0.315f, Y = 0.725f });
 
         var vespeneMiners = activeMiningModules.Count(module => module.ResourceType == Resources.ResourceType.Gas);
         Program.GraphicalDebugger.AddTextGroup(new[]
         {
-            $"Vespene" + $"{$"({vespeneMiners})",6}",
-            $"Max: {IncomeTracker.MaxVespeneCollectionRate, 8:F0}",
-            $"Average: {IncomeTracker.AverageVespeneCollectionRate, 4:F0}",
-            $"Current: {IncomeTracker.CurrentVespeneCollectionRate, 4:F0}",
-        }, virtualPos: new Point { X = 0.410f, Y = 0.740f });
+            $"Vespene" + $"{$"({vespeneMiners})",7}",
+            $"Max: {IncomeTracker.MaxVespeneCollectionRate, 9:F0}",
+            $"Average: {IncomeTracker.AverageVespeneCollectionRate, 5:F0}",
+            $"Current: {IncomeTracker.CurrentVespeneCollectionRate, 5:F0}",
+            $"Expected: {IncomeTracker.ExpectedVespeneCollectionRate, 4:F0}",
+        }, virtualPos: new Point { X = 0.410f, Y = 0.725f });
+    }
+
+    private static void DebugFutureSpending() {
+        if (!DebuggingFlagsTracker.IsActive(DebuggingFlags.Spend)) {
+            return;
+        }
+
+        var mineralsToGasRatio = SpendingTracker.ExpectedFutureMineralsSpending / SpendingTracker.ExpectedFutureVespeneSpending;
+        Program.GraphicalDebugger.AddTextGroup(new[]
+        {
+            "Future spending",
+            $"Minerals: {SpendingTracker.ExpectedFutureMineralsSpending, 8:F0}",
+            $"Gas: {SpendingTracker.ExpectedFutureVespeneSpending, 13:F0}",
+            // SC2 cannot render the infinity character, so we show "INF" instead
+            $"Minerals/Gas: {(SpendingTracker.ExpectedFutureVespeneSpending == 0 ? "INF" : mineralsToGasRatio), 4:F1}",
+        }, virtualPos: new Point { X = 0.505f, Y = 0.740f });
     }
 
     private static void DebugEnemyGhostUnits() {

--- a/Bot/Debugging/BotDebugger.cs
+++ b/Bot/Debugging/BotDebugger.cs
@@ -15,6 +15,7 @@ namespace Bot.Debugging;
 
 public class BotDebugger {
     private float _maxMineralRate = 0;
+    private float _maxVespeneRate = 0;
 
     public void Debug(List<BuildFulfillment> managerBuildRequests, (BuildFulfillment, BuildBlockCondition) buildBlockStatus) {
         if (!Program.DebugEnabled) {
@@ -109,12 +110,20 @@ public class BotDebugger {
         }
 
         var scoreDetails = Controller.Observation.Observation.Score.ScoreDetails;
+
         _maxMineralRate = Math.Max(_maxMineralRate, scoreDetails.CollectionRateMinerals);
         Program.GraphicalDebugger.AddTextGroup(new[]
         {
-            $"Max minerals rate: {_maxMineralRate}",
-            $"Minerals rate: {scoreDetails.CollectionRateMinerals}",
+            $"Max minerals rate: {_maxMineralRate, 4}",
+            $"Minerals rate: {scoreDetails.CollectionRateMinerals, 8}",
         }, virtualPos: new Point { X = 0.315f, Y = 0.765f });
+
+        _maxVespeneRate = Math.Max(_maxVespeneRate, scoreDetails.CollectionRateVespene);
+        Program.GraphicalDebugger.AddTextGroup(new[]
+        {
+            $"Max vespene rate: {_maxVespeneRate, 4}",
+            $"Vespene rate: {scoreDetails.CollectionRateVespene, 8}",
+        }, virtualPos: new Point { X = 0.455f, Y = 0.765f });
     }
 
     private static void DebugEnemyGhostUnits() {

--- a/Bot/Debugging/DebuggingFlags.cs
+++ b/Bot/Debugging/DebuggingFlags.cs
@@ -34,6 +34,11 @@ public static class DebuggingFlags {
     public const string IncomeRate = ".income";
 
     /// <summary>
+    /// Enables displaying future spending information on screen
+    /// </summary>
+    public const string Spend = ".spend";
+
+    /// <summary>
     /// Enables displaying ghost units data
     /// </summary>
     public const string GhostUnits = ".ghost";

--- a/Bot/Debugging/DebuggingFlagsTracker.cs
+++ b/Bot/Debugging/DebuggingFlagsTracker.cs
@@ -30,6 +30,7 @@ public class DebuggingFlagsTracker : INeedUpdating {
         _activeDebuggingFlags.Add(DebuggingFlags.BuildOrder);
         _activeDebuggingFlags.Add(DebuggingFlags.MatchupData);
         _activeDebuggingFlags.Add(DebuggingFlags.IncomeRate);
+        _activeDebuggingFlags.Add(DebuggingFlags.Spend);
         _activeDebuggingFlags.Add(DebuggingFlags.EnemyDetectors);
         _activeDebuggingFlags.Add(DebuggingFlags.GhostUnits);
         _activeDebuggingFlags.Add(DebuggingFlags.KnownEnemyUnits);

--- a/Bot/GameData/Units.cs
+++ b/Bot/GameData/Units.cs
@@ -700,7 +700,7 @@ public static class Units {
     #region Resources
 
     // Mineral field types seem to differ from map to map
-    public static readonly HashSet<uint> NormalMineralFields = new HashSet<uint>
+    public static readonly HashSet<uint> BlueMineralFields = new HashSet<uint>
     {
         MineralField,
         MineralField750,
@@ -721,10 +721,10 @@ public static class Units {
         PurifierRichMineralField750,
     };
 
-    public static readonly HashSet<uint> MineralFields = new HashSet<uint>(NormalMineralFields.Concat(GoldMineralFields));
+    public static readonly HashSet<uint> MineralFields = new HashSet<uint>(BlueMineralFields.Concat(GoldMineralFields));
 
     // Gas geyser types seem to differ from map to map
-    public static readonly HashSet<uint> NormalGasGeysers = new HashSet<uint>
+    public static readonly HashSet<uint> GreenGasGeysers = new HashSet<uint>
     {
         VespeneGeyser,
         SpacePlatformGeyser,
@@ -734,12 +734,12 @@ public static class Units {
         ShakurasVespeneGeyser,
     };
 
-    public static readonly HashSet<uint> GoldGasGeysers = new HashSet<uint>
+    public static readonly HashSet<uint> PurpleGasGeysers = new HashSet<uint>
     {
         RichVespeneGeyser,
     };
 
-    public static readonly HashSet<uint> GasGeysers = new HashSet<uint>(NormalGasGeysers.Concat(GoldGasGeysers));
+    public static readonly HashSet<uint> GasGeysers = new HashSet<uint>(GreenGasGeysers.Concat(PurpleGasGeysers));
 
     #endregion
 }

--- a/Bot/GameSense/IncomeTracker.cs
+++ b/Bot/GameSense/IncomeTracker.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using Bot.Utils;
+using SC2APIProtocol;
+
+namespace Bot.GameSense;
+
+public class IncomeTracker : INeedUpdating {
+    public static readonly IncomeTracker Instance = new IncomeTracker();
+
+    private readonly CircularQueue<float> _mineralsCollectionRates = new CircularQueue<float>((int)(TimeUtils.FramesPerSecond * 30));
+    private readonly CircularQueue<float> _vespeneCollectionRates = new CircularQueue<float>((int)(TimeUtils.FramesPerSecond * 30));
+
+    public static float CurrentMineralsCollectionRate { get; private set; }
+    public static float MaxMineralsCollectionRate { get; private set; }
+    public static float AverageMineralsCollectionRate { get; private set; }
+
+    public static float CurrentVespeneCollectionRate { get; private set; }
+    public static float MaxVespeneCollectionRate { get; private set; }
+    public static float AverageVespeneCollectionRate { get; private set; }
+
+    private IncomeTracker() {}
+
+    public void Reset() {
+        _mineralsCollectionRates.Clear();
+        _vespeneCollectionRates.Clear();
+    }
+
+    public void Update(ResponseObservation observation) {
+        var scoreDetails = observation.Observation.Score.ScoreDetails;
+        UpdateMineralsCollectionRates(scoreDetails.CollectionRateMinerals);
+        UpdateVespeneCollectionRates(scoreDetails.CollectionRateVespene);
+    }
+
+    private void UpdateMineralsCollectionRates(float currentCollectionRateMinerals) {
+        CurrentMineralsCollectionRate = currentCollectionRateMinerals;
+        _mineralsCollectionRates.Enqueue(currentCollectionRateMinerals);
+
+        MaxMineralsCollectionRate = _mineralsCollectionRates.Max();
+        AverageMineralsCollectionRate = _mineralsCollectionRates.Average();
+    }
+
+    private void UpdateVespeneCollectionRates(float currentCollectionRateVespene) {
+        CurrentVespeneCollectionRate = currentCollectionRateVespene;
+        _vespeneCollectionRates.Enqueue(currentCollectionRateVespene);
+
+        MaxVespeneCollectionRate = _vespeneCollectionRates.Max();
+        AverageVespeneCollectionRate = _vespeneCollectionRates.Average();
+    }
+}

--- a/Bot/GameSense/IncomeTracker.cs
+++ b/Bot/GameSense/IncomeTracker.cs
@@ -7,6 +7,7 @@ namespace Bot.GameSense;
 public class IncomeTracker : INeedUpdating {
     public static readonly IncomeTracker Instance = new IncomeTracker();
 
+    private const int LogCollectedMineralsFrame = (int)(90 * TimeUtils.FramesPerSecond);
     private readonly CircularQueue<float> _mineralsCollectionRates = new CircularQueue<float>((int)(TimeUtils.FramesPerSecond * 30));
     private readonly CircularQueue<float> _vespeneCollectionRates = new CircularQueue<float>((int)(TimeUtils.FramesPerSecond * 30));
 
@@ -29,6 +30,12 @@ public class IncomeTracker : INeedUpdating {
         var scoreDetails = observation.Observation.Score.ScoreDetails;
         UpdateMineralsCollectionRates(scoreDetails.CollectionRateMinerals);
         UpdateVespeneCollectionRates(scoreDetails.CollectionRateVespene);
+
+        if (Controller.Frame == LogCollectedMineralsFrame) {
+            var mineralsCollected = observation.Observation.Score.ScoreDetails.CollectedMinerals;
+            Logger.Metric("Collected Minerals: {0}", mineralsCollected);
+            TaggingService.TagGame(TaggingService.Tag.Minerals, mineralsCollected);
+        }
     }
 
     private void UpdateMineralsCollectionRates(float currentCollectionRateMinerals) {

--- a/Bot/GameSense/SpendingTracker.cs
+++ b/Bot/GameSense/SpendingTracker.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using Bot.Builds;
+using Bot.GameData;
+
+namespace Bot.GameSense;
+
+// This doesn't need to be a global static class
+// It could be created by Sajuuk and given to the EconomyManager
+// But at the same time, we don't want two of these
+// Soooo... yeah, whatever!
+public static class SpendingTracker {
+    public static float ExpectedFutureMineralsSpending { get; private set; }
+    public static float ExpectedFutureVespeneSpending { get; private set; }
+
+    /// <summary>
+    /// Update the expected future spending.
+    /// We look at the future build requests and we compile how much minerals and gas we want to spend.
+    ///
+    /// We limit the sum to the minerals and gas income of the next minute.
+    /// This effectively prioritizes expenses that will happen soon.
+    /// </summary>
+    /// <param name="futureBuildRequests"></param>
+    public static void UpdateExpectedFutureSpending(List<BuildFulfillment> futureBuildRequests) {
+        ExpectedFutureMineralsSpending = 0;
+        ExpectedFutureVespeneSpending = 0;
+
+        // TODO GD The list is sorted by priority, then supply, with "atSupply: 0" being last
+        // Because of this, if there's a lot of things planned for the future, we won't be counting "atSupply: 0" build requests, but in reality we'll execute them before
+        // We could (should) adjust the logic accordingly
+        var spendingLimit = IncomeTracker.ExpectedMineralsCollectionRate + IncomeTracker.ExpectedVespeneCollectionRate;
+        foreach (var buildRequest in futureBuildRequests) {
+            var mineralSpending = 0f;
+            var vespeneSpending = 0f;
+
+            if (buildRequest.BuildType == BuildType.Research) {
+                var upgradeTypeData = KnowledgeBase.GetUpgradeData(buildRequest.UnitOrUpgradeType);
+                mineralSpending += buildRequest.Remaining * upgradeTypeData.MineralCost;
+                vespeneSpending += buildRequest.Remaining * upgradeTypeData.VespeneCost;
+            }
+            else {
+                var unitTypeData = KnowledgeBase.GetUnitTypeData(buildRequest.UnitOrUpgradeType);
+                mineralSpending += buildRequest.Remaining * unitTypeData.MineralCost;
+                vespeneSpending += buildRequest.Remaining * unitTypeData.VespeneCost;
+            }
+
+            var totalSpending = mineralSpending + vespeneSpending;
+            var allowedPercent = Math.Min(1, spendingLimit / totalSpending);
+
+            ExpectedFutureMineralsSpending += mineralSpending * allowedPercent;
+            ExpectedFutureVespeneSpending += vespeneSpending * allowedPercent;
+
+            spendingLimit -= totalSpending * allowedPercent;
+
+            if (allowedPercent < 1) {
+                break;
+            }
+        }
+    }
+}

--- a/Bot/Managers/BuildManager.cs
+++ b/Bot/Managers/BuildManager.cs
@@ -6,8 +6,9 @@ using Bot.GameSense.EnemyStrategyTracking;
 namespace Bot.Managers;
 
 public class BuildManager : UnitlessManager, ISubscriber<EnemyStrategyTransition> {
-    private bool _buildOrderDoneAndTagged = false;
     private readonly IBuildOrder _buildOrder;
+
+    public bool IsBuildOrderDone { get; private set; } = false;
 
     public override IEnumerable<BuildFulfillment> BuildFulfillments => _buildOrder.BuildRequests.Select(buildRequest => buildRequest.Fulfillment);
 
@@ -19,12 +20,12 @@ public class BuildManager : UnitlessManager, ISubscriber<EnemyStrategyTransition
     protected override void ManagementPhase() {
         _buildOrder.PruneRequests();
 
-        if (!_buildOrderDoneAndTagged) {
+        if (!IsBuildOrderDone) {
             var buildOrderDone = _buildOrder.BuildRequests.All(request => request.Fulfillment.Remaining == 0);
             if (buildOrderDone) {
                 var scoreDetails = Controller.Observation.Observation.Score.ScoreDetails;
                 TaggingService.TagGame(TaggingService.Tag.BuildDone, Controller.CurrentSupply, scoreDetails.CollectedMinerals, scoreDetails.CollectedVespene);
-                _buildOrderDoneAndTagged = true;
+                IsBuildOrderDone = true;
             }
         }
     }

--- a/Bot/Managers/BuildManager.cs
+++ b/Bot/Managers/BuildManager.cs
@@ -22,7 +22,8 @@ public class BuildManager : UnitlessManager, ISubscriber<EnemyStrategyTransition
         if (!_buildOrderDoneAndTagged) {
             var buildOrderDone = _buildOrder.BuildRequests.All(request => request.Fulfillment.Remaining == 0);
             if (buildOrderDone) {
-                TaggingService.TagGame(TaggingService.Tag.BuildDone);
+                var scoreDetails = Controller.Observation.Observation.Score.ScoreDetails;
+                TaggingService.TagGame(TaggingService.Tag.BuildDone, Controller.CurrentSupply, scoreDetails.CollectedMinerals, scoreDetails.CollectedVespene);
                 _buildOrderDoneAndTagged = true;
             }
         }

--- a/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisor.cs
+++ b/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisor.cs
@@ -11,10 +11,6 @@ using SC2APIProtocol;
 namespace Bot.Managers.EconomyManagement.TownHallSupervision;
 
 public partial class TownHallSupervisor: Supervisor, IWatchUnitsDie {
-    private const int MaxPerExtractor = 3;
-    private const int IdealPerMinerals = 2;
-    private const int MaxPerMinerals = 3;
-
     private readonly ulong _id;
     private readonly Color _color;
     public Unit TownHall { get; private set; }
@@ -36,7 +32,7 @@ public partial class TownHallSupervisor: Supervisor, IWatchUnitsDie {
     protected override IAssigner Assigner { get; }
     protected override IReleaser Releaser { get; }
 
-    public int IdealCapacity => _minerals.Count * IdealPerMinerals + _extractors.Count(extractor => extractor.IsOperational) * MaxPerExtractor;
+    public int IdealCapacity => _minerals.Count * Resources.IdealDronesPerMinerals + _extractors.Count(extractor => extractor.IsOperational) * Resources.MaxDronesPerExtractor;
     public int IdealAvailableCapacity => IdealCapacity - _workers.Count;
 
     public int SaturatedCapacity => IdealCapacity + _minerals.Count; // Can allow 1 more per mineral patch;
@@ -45,9 +41,8 @@ public partial class TownHallSupervisor: Supervisor, IWatchUnitsDie {
     public int WorkerCount => _workers.Count;
 
     // TODO GD Checking that the extractor is operational is annoying
-    public int MaxGasCapacity => Math.Min(WorkerCount, _extractors.Count(extractor => extractor.IsOperational) * MaxPerExtractor);
-    private int GasWorkerCount => _extractors.Sum(extractor => UnitModule.Get<CapacityModule>(extractor).AssignedUnits.Count);
-    public int GasWorkersCap = 0; // To be set by the manager
+    public int MaxGasCapacity => Math.Min(WorkerCount, _extractors.Count(extractor => extractor.IsOperational) * Resources.MaxDronesPerExtractor);
+    public int GasWorkersCap = 0;
 
     public TownHallSupervisor(Unit townHall, Color color) {
         _id = townHall.Tag;
@@ -162,7 +157,7 @@ public partial class TownHallSupervisor: Supervisor, IWatchUnitsDie {
         var availableCapacity = GasWorkersCap;
         foreach (var extractor in _extractors.Where(extractor => extractor.IsOperational)) {
             var capacityModule = UnitModule.Get<CapacityModule>(extractor);
-            var newExtractorCapacity = Math.Min(MaxPerExtractor, availableCapacity);
+            var newExtractorCapacity = Math.Min(Resources.MaxDronesPerExtractor, availableCapacity);
 
             capacityModule.MaxCapacity = newExtractorCapacity;
             availableCapacity -= newExtractorCapacity;

--- a/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisorAssigner.cs
+++ b/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisorAssigner.cs
@@ -123,7 +123,7 @@ public partial class TownHallSupervisor {
             _supervisor._gasses.Add(gas);
 
             DebugLocationModule.Install(gas, _supervisor._color);
-            CapacityModule.Install(gas, MaxExtractorsPerGas);
+            CapacityModule.Install(gas, MaxExtractorsPerGas, showDebugInfo: false);
 
             LogAssignment(gas);
         }

--- a/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisorAssigner.cs
+++ b/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisorAssigner.cs
@@ -100,7 +100,7 @@ public partial class TownHallSupervisor {
             _supervisor._extractors.Add(extractor);
 
             DebugLocationModule.Install(extractor, _supervisor._color);
-            CapacityModule.Install(extractor, MaxPerExtractor);
+            CapacityModule.Install(extractor, Resources.MaxDronesPerExtractor);
 
             UnitModule.Get<CapacityModule>(_supervisor._gasses.First(gas => gas.DistanceTo(extractor) < 1)).Assign(extractor); // TODO GD Make this cleaner
 
@@ -113,7 +113,7 @@ public partial class TownHallSupervisor {
             _supervisor._minerals.Add(mineral);
 
             DebugLocationModule.Install(mineral, _supervisor._color);
-            CapacityModule.Install(mineral, MaxPerMinerals);
+            CapacityModule.Install(mineral, Resources.MaxDronesPerMinerals);
 
             LogAssignment(mineral);
         }

--- a/Bot/Managers/UpgradesManager.cs
+++ b/Bot/Managers/UpgradesManager.cs
@@ -41,6 +41,10 @@ public class UpgradesManager : UnitlessManager {
 
         foreach (var buildRequest in _buildRequests) {
             buildRequest.Priority = BuildRequestPriority.Medium;
+
+            if (buildRequest.BuildType == BuildType.Research) {
+                buildRequest.BlockCondition = BuildBlockCondition.MissingResources;
+            }
         }
     }
 

--- a/Bot/Managers/UpgradesManager.cs
+++ b/Bot/Managers/UpgradesManager.cs
@@ -88,7 +88,6 @@ public class UpgradesManager : UnitlessManager {
         }
 
         if (roachCount >= 27) {
-            _buildRequests.Add(new TargetBuildRequest(BuildType.Build,    Units.Extractor,                   targetQuantity: 4));
             _buildRequests.Add(new TargetBuildRequest(BuildType.Research, Upgrades.ZergMissileWeaponsLevel2, targetQuantity: 1));
             _buildRequests.Add(new TargetBuildRequest(BuildType.Research, Upgrades.ZergGroundArmorsLevel2,   targetQuantity: 1));
             _requestedUpgrades.Add(Upgrades.ZergMissileWeaponsLevel2);

--- a/Bot/MapKnowledge/ExpandAnalyzer/ExpandAnalyzer.cs
+++ b/Bot/MapKnowledge/ExpandAnalyzer/ExpandAnalyzer.cs
@@ -277,7 +277,7 @@ public class ExpandAnalyzer: INeedUpdating {
     /// <param name="resourceCluster">The resource cluster associated with the expand</param>
     /// <returns>True if the resource cluster associated with the expand contains rich resources</returns>
     private static bool IsGoldExpand(IEnumerable<Unit> resourceCluster) {
-        return resourceCluster.Any(resource => Units.GoldMineralFields.Contains(resource.UnitType) || Units.GoldGasGeysers.Contains(resource.UnitType));
+        return resourceCluster.Any(resource => Units.GoldMineralFields.Contains(resource.UnitType) || Units.PurpleGasGeysers.Contains(resource.UnitType));
     }
 
     /// <summary>

--- a/Bot/Program.cs
+++ b/Bot/Program.cs
@@ -24,7 +24,7 @@ public class Program {
 
     private const string MapFileName = Maps.Season_2022_4.FileNames.Moondance;
     private const Race OpponentRace = Race.Terran;
-    private const Difficulty OpponentDifficulty = Difficulty.VeryEasy;
+    private const Difficulty OpponentDifficulty = Difficulty.VeryHard;
 
     private const bool RealTime = false;
 

--- a/Bot/Program.cs
+++ b/Bot/Program.cs
@@ -24,7 +24,7 @@ public class Program {
 
     private const string MapFileName = Maps.Season_2022_4.FileNames.Moondance;
     private const Race OpponentRace = Race.Terran;
-    private const Difficulty OpponentDifficulty = Difficulty.Hard;
+    private const Difficulty OpponentDifficulty = Difficulty.VeryEasy;
 
     private const bool RealTime = false;
 

--- a/Bot/Resources.cs
+++ b/Bot/Resources.cs
@@ -3,6 +3,10 @@
 namespace Bot;
 
 public static class Resources {
+    public const int MaxDronesPerExtractor = 3;
+    public const int IdealDronesPerMinerals = 2;
+    public const int MaxDronesPerMinerals = 3;
+
     public enum ResourceType {
         None,
         Mineral,

--- a/Bot/SajuukBot.cs
+++ b/Bot/SajuukBot.cs
@@ -61,7 +61,7 @@ public class SajuukBot: PoliteBot {
 
         _managers.Add(new SupplyManager(buildManager));
         _managers.Add(new ScoutManager());
-        _managers.Add(new EconomyManager());
+        _managers.Add(new EconomyManager(buildManager));
         _managers.Add(new WarManager());
         _managers.Add(new CreepManager());
         _managers.Add(new UpgradesManager());

--- a/Bot/SajuukBot.cs
+++ b/Bot/SajuukBot.cs
@@ -31,9 +31,6 @@ public class SajuukBot: PoliteBot {
         if (Controller.Frame == 0) {
             InitManagers();
         }
-        else if (Controller.Frame == 2016) {
-            Logger.Metric("Collected Minerals: {0}", Controller.Observation.Observation.Score.ScoreDetails.CollectedMinerals);
-        }
 
         _managers.ForEach(manager => manager.OnFrame());
 

--- a/Bot/SajuukBot.cs
+++ b/Bot/SajuukBot.cs
@@ -37,10 +37,14 @@ public class SajuukBot: PoliteBot {
         var managerRequests = GetManagersBuildRequests();
         var buildBlockStatus = AddressManagerRequests(managerRequests);
 
+        var flatManagerRequests = managerRequests
+            .SelectMany(groupedBySupply => groupedBySupply.SelectMany(request => request))
+            .ToList();
+
+        SpendingTracker.UpdateExpectedFutureSpending(flatManagerRequests);
+
         _debugger.Debug(
-            managerRequests
-                .SelectMany(groupedBySupply => groupedBySupply.SelectMany(request => request))
-                .ToList(),
+            flatManagerRequests,
             buildBlockStatus
         );
 
@@ -96,6 +100,7 @@ public class SajuukBot: PoliteBot {
                         }
                         else if (ShouldBlock(buildStep, buildStepResult, out var buildBlockingReason)) {
                             // We must wait to fulfill this one
+                            // TODO GD We can still process other requests that don't overlap with the blocking condition
                             return (buildStep, buildBlockingReason);
                         }
                         else {

--- a/Bot/TaggingService.cs
+++ b/Bot/TaggingService.cs
@@ -46,7 +46,7 @@ public static class TaggingService {
         {
             Tag.TerranFinisher => $"{tag}_{gameTimeString}",
             Tag.EarlyAttack => $"{tag}_{gameTimeString}",
-            Tag.BuildDone => $"{tag}_{gameTimeString}_Supply_{Controller.CurrentSupply}",
+            Tag.BuildDone => $"{tag}_{gameTimeString}_S{parameters[0]}_M{parameters[1]}_V{parameters[2]}",
 
             // We print "EnemyStrategy" as "Enemy" to have more space for the enemy strategy name, otherwise it gets truncated
             Tag.EnemyStrategy => $"Enemy_{parameters[0]}_{gameTimeString}",

--- a/Bot/TaggingService.cs
+++ b/Bot/TaggingService.cs
@@ -13,6 +13,7 @@ public static class TaggingService {
         EnemyStrategy,
         Version,
         TerranFinisher,
+        Minerals,
     }
 
     public static void TagGame(Tag tag, params object[] parameters) {
@@ -51,6 +52,7 @@ public static class TaggingService {
             Tag.EnemyStrategy => $"Enemy_{parameters[0]}_{gameTimeString}",
 
             Tag.Version => $"v{parameters[0]}",
+            Tag.Minerals => $"{tag}_{parameters[0]}",
             _ => tag.ToString(),
         };
     }

--- a/Bot/TaggingService.cs
+++ b/Bot/TaggingService.cs
@@ -31,7 +31,7 @@ public static class TaggingService {
         TagsSent.Add(tag);
     }
 
-    private static bool CanTag(Tag tag) {
+    public static bool CanTag(Tag tag) {
         return tag switch
         {
             Tag.EnemyStrategy => true,

--- a/Bot/UnitModules/CapacityModule.cs
+++ b/Bot/UnitModules/CapacityModule.cs
@@ -8,24 +8,30 @@ public class CapacityModule: UnitModule, IWatchUnitsDie {
     public const string Tag = "CapacityModule";
 
     private readonly Unit _unit;
+    private readonly bool _showDebugInfo;
 
     public int MaxCapacity;
     public readonly List<Unit> AssignedUnits = new List<Unit>();
 
     public int AvailableCapacity => MaxCapacity - AssignedUnits.Count;
 
-    public static void Install(Unit unit, int maxCapacity) {
+    public static void Install(Unit unit, int maxCapacity, bool showDebugInfo = true) {
         if (PreInstallCheck(Tag, unit)) {
-            unit.Modules.Add(Tag, new CapacityModule(unit, maxCapacity));
+            unit.Modules.Add(Tag, new CapacityModule(unit, maxCapacity, showDebugInfo));
         }
     }
 
-    private CapacityModule(Unit unit, int maxCapacity) {
+    private CapacityModule(Unit unit, int maxCapacity, bool showDebugInfo) {
         _unit = unit;
         MaxCapacity = maxCapacity;
+        _showDebugInfo = showDebugInfo;
     }
 
     protected override void DoExecute() {
+        if (!_showDebugInfo) {
+            return;
+        }
+
         var color = AvailableCapacity switch
         {
             > 0 => Colors.Green,

--- a/Bot/UnitModules/CapacityModule.cs
+++ b/Bot/UnitModules/CapacityModule.cs
@@ -8,10 +8,11 @@ public class CapacityModule: UnitModule, IWatchUnitsDie {
     public const string Tag = "CapacityModule";
 
     private readonly Unit _unit;
-    private readonly int _maxCapacity;
+
+    public int MaxCapacity;
     public readonly List<Unit> AssignedUnits = new List<Unit>();
 
-    public int AvailableCapacity => _maxCapacity - AssignedUnits.Count;
+    public int AvailableCapacity => MaxCapacity - AssignedUnits.Count;
 
     public static void Install(Unit unit, int maxCapacity) {
         if (PreInstallCheck(Tag, unit)) {
@@ -21,7 +22,7 @@ public class CapacityModule: UnitModule, IWatchUnitsDie {
 
     private CapacityModule(Unit unit, int maxCapacity) {
         _unit = unit;
-        _maxCapacity = maxCapacity;
+        MaxCapacity = maxCapacity;
     }
 
     protected override void DoExecute() {
@@ -32,7 +33,7 @@ public class CapacityModule: UnitModule, IWatchUnitsDie {
             < 0 => Colors.Red,
         };
 
-        Program.GraphicalDebugger.AddText($"{AssignedUnits.Count}/{_maxCapacity}", color: color, worldPos: _unit.Position.ToPoint(xOffset: -0.2f));
+        Program.GraphicalDebugger.AddText($"{AssignedUnits.Count}/{MaxCapacity}", color: color, worldPos: _unit.Position.ToPoint(xOffset: -0.2f));
     }
 
     public void ReportUnitDeath(Unit deadUnit) {

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Check out [Artificially Intelligent](https://www.youtube.com/channel/UC_KAanPGVo
 - Overlord scouting
 - BuildRequest system with dynamic Priorities and BlockConditions
 - Regions value and force evaluations to decide where to defend and where to attack
+- Automatic gas/minerals balancing


### PR DESCRIPTION
# Description
The gas management was previously hardcoded in the build and there was no logic to adjust for gas floods or starves.  
This made the build tedious to make, but it also made the bot unable to recover from certain situations by itself.  

# What's new
- Added an `IncomeTracker` to track our income
  - It computes a rolling window average of our past income
  - It also estimates the income based on drone assignments
  - Since we had the real data and the estimated data, we were able to conclude that the estimation was reliable!
  - We moved the 1:30 resource tagging logic in here
- Added a `SpendingTracker` to track the future expected expenditures.
  - This mechanism allows us to know how much gas we'll need
  - In conjuction with income estimations, we're able to distribute drones properly
- The `TownHallSupervisor` now has a `GasWorkersCap` and will always try to satisfy it
  - It no longer only assigns to gas after the mineral line has reached 12 drones
- The `EconomyManager` now dictates how many drones in gas each supervisor should have and it requests extractors as well
  - **It will not manage the gas before the build order is done, because the build order timings are already optimized.**
- We added resource collected info in the build done tag
- Added income/spend debug UI