### PR TITLE
Feature - Early game overlord management

### DIFF
--- a/Bot/Builds/BuildOrders/TwoBasesRoach.cs
+++ b/Bot/Builds/BuildOrders/TwoBasesRoach.cs
@@ -16,22 +16,22 @@ public class TwoBasesRoach : IBuildOrder {
     public TwoBasesRoach() {
         _buildRequests = new List<BuildRequest>
         {
-            new QuantityBuildRequest(BuildType.Train,       Units.Overlord,                    atSupply: 13),
+            new TargetBuildRequest  (BuildType.Train,       Units.Overlord,                    atSupply: 13, targetQuantity: 2),
             new QuantityBuildRequest(BuildType.Expand,      Units.Hatchery,                    atSupply: 16),                    // TODO GD Need to be able to say 1 expand as opposed to 2 hatcheries
             // TODO GD The build requests are sorted by supply, so the pool gets built before the gas. It doesn't matter, but don't forget
             new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 18, targetQuantity: 1),
             new TargetBuildRequest  (BuildType.Build,       Units.SpawningPool,                atSupply: 17, targetQuantity: 1),
-            new QuantityBuildRequest(BuildType.Train,       Units.Overlord,                    atSupply: 19),
+            new TargetBuildRequest  (BuildType.Train,       Units.Overlord,                    atSupply: 19, targetQuantity: 3),
             new TargetBuildRequest  (BuildType.Train,       Units.Queen,                       atSupply: 22, targetQuantity: 2),
             new QuantityBuildRequest(BuildType.Train,       Units.Zergling,                    atSupply: 24, quantity: 2),
-            new QuantityBuildRequest(BuildType.Train,       Units.Overlord,                    atSupply: 30),
+            new TargetBuildRequest  (BuildType.Train,       Units.Overlord,                    atSupply: 30, targetQuantity: 4),
             new TargetBuildRequest  (BuildType.Train,       Units.Queen,                       atSupply: 30, targetQuantity: 3),
             new TargetBuildRequest  (BuildType.UpgradeInto, Units.Lair,                        atSupply: 33, targetQuantity: 1),
             new TargetBuildRequest  (BuildType.Build,       Units.RoachWarren,                 atSupply: 33, targetQuantity: 1),
             new TargetBuildRequest  (BuildType.Build,       Units.EvolutionChamber,            atSupply: 37, targetQuantity: 1),
             new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 37, targetQuantity: 2),
             new TargetBuildRequest  (BuildType.Research,    Upgrades.Burrow,                   atSupply: 40, targetQuantity: 1),
-            new QuantityBuildRequest(BuildType.Train,       Units.Overlord,                    atSupply: 41),
+            new TargetBuildRequest  (BuildType.Train,       Units.Overlord,                    atSupply: 41, targetQuantity: 5),
             new TargetBuildRequest  (BuildType.Research,    Upgrades.ZergMissileWeaponsLevel1, atSupply: 44, targetQuantity: 1),
             new TargetBuildRequest  (BuildType.Build,       Units.Extractor,                   atSupply: 50, targetQuantity: 3),
             new TargetBuildRequest  (BuildType.Research,    Upgrades.TunnelingClaws,           atSupply: 50, targetQuantity: 1),

--- a/Bot/Controller.cs
+++ b/Bot/Controller.cs
@@ -36,7 +36,7 @@ public static class Controller {
     public static uint MaxSupply { get; private set; }
     public static int AvailableSupply => (int)(MaxSupply - CurrentSupply);
 
-    public static bool IsSupplyCapped => AvailableSupply == 0;
+    public static bool IsSupplyCapped => AvailableSupply <= 0;
 
     public static int AvailableMinerals { get; private set; }
     public static int AvailableVespene { get; private set; }

--- a/Bot/Managers/EconomyManagement/EconomyManager.cs
+++ b/Bot/Managers/EconomyManagement/EconomyManager.cs
@@ -113,8 +113,12 @@ public sealed partial class EconomyManager: Manager {
     private void AdjustGasProduction() {
         // The build order is optimized, take all the gas we can
         if (!_buildManager.IsBuildOrderDone) {
+            // There can be scenarios where we lose most of our drones early game
+            // When that happens, we must really focus on minerals
+            var hasEnoughDronesForGas = ManagedUnits.Count(unit => unit.UnitType == Units.Drone) >= 10;
+
             foreach (var townHallSupervisor in _townHallSupervisors) {
-                townHallSupervisor.GasWorkersCap = townHallSupervisor.MaxGasCapacity;
+                townHallSupervisor.GasWorkersCap = hasEnoughDronesForGas ? townHallSupervisor.MaxGasCapacity : 0;
             }
 
             return;

--- a/Bot/Managers/Manager.cs
+++ b/Bot/Managers/Manager.cs
@@ -26,6 +26,8 @@ public abstract class Manager: IWatchUnitsDie {
     protected abstract void ManagementPhase();
     protected virtual void EndOfFramePhase() {}
 
+    protected virtual void OnManagedUnitDeath(Unit deadUnit) {}
+
     public void Assign(IEnumerable<Unit> units) {
         foreach (var unit in units) {
             Assign(unit);
@@ -85,6 +87,7 @@ public abstract class Manager: IWatchUnitsDie {
     public void ReportUnitDeath(Unit deadUnit) {
         if (ManagedUnits.Contains(deadUnit)) {
             Release(deadUnit);
+            OnManagedUnitDeath(deadUnit);
         }
         else {
             Logger.Error("({0}) Reported death of {1}, but we don't manage this unit", this, deadUnit);

--- a/Bot/Managers/ScoutManagement/ScoutManager.cs
+++ b/Bot/Managers/ScoutManagement/ScoutManager.cs
@@ -110,4 +110,13 @@ public partial class ScoutManager : Manager {
             _scoutSupervisors.Remove(scoutSupervisor);
         }
     }
+
+    protected override void OnManagedUnitDeath(Unit deadUnit) {
+        // Our logic to protect scouts is bad right now
+        // If we start losing scouts, abort all scouting and recall everyone
+        foreach (var scoutSupervisor in _scoutSupervisors) {
+            scoutSupervisor.Retire();
+            _scoutSupervisors.Remove(scoutSupervisor);
+        }
+    }
 }

--- a/Bot/Managers/ScoutManagement/ScoutingSupervision/ScoutSupervisor.cs
+++ b/Bot/Managers/ScoutManagement/ScoutingSupervision/ScoutSupervisor.cs
@@ -44,6 +44,7 @@ public partial class ScoutSupervisor : Supervisor {
     }
 
     public override void Retire() {
+        ScoutingTask.Cancel();
         foreach (var supervisedUnit in SupervisedUnits) {
             Release(supervisedUnit);
         }

--- a/Bot/Managers/ScoutManagement/ScoutingTasks/ScoutingTask.cs
+++ b/Bot/Managers/ScoutManagement/ScoutingTasks/ScoutingTask.cs
@@ -9,7 +9,7 @@ public abstract class ScoutingTask {
     /**
      * High priority is more important
      */
-    public int Priority { get; }
+    public int Priority { get; set; }
 
     public int MaxScouts { get; }
 

--- a/Bot/Managers/SupplyManager.cs
+++ b/Bot/Managers/SupplyManager.cs
@@ -32,6 +32,10 @@ public class SupplyManager : UnitlessManager {
             // TODO GD Be smarter about the batch size
             _overlordsBuildRequest.Requested += OverlordBatchSize;
         }
+
+        if (IsSupplyCapped()) {
+            _overlordsBuildRequest.Requested += 1;
+        }
     }
 
     private void MaintainOverlords() {
@@ -60,5 +64,9 @@ public class SupplyManager : UnitlessManager {
 
     private int GetRequestedSupportedSupply() {
         return _overlordsBuildRequest.Requested * SupplyPerOverlord + GetSupplyFromHatcheries();
+    }
+
+    private bool IsSupplyCapped() {
+        return _overlordsBuildRequest.Fulfillment.Remaining == 0 && Controller.IsSupplyCapped;
     }
 }

--- a/Bot/Managers/SupplyManager.cs
+++ b/Bot/Managers/SupplyManager.cs
@@ -32,10 +32,6 @@ public class SupplyManager : UnitlessManager {
             // TODO GD Be smarter about the batch size
             _overlordsBuildRequest.Requested += OverlordBatchSize;
         }
-
-        if (IsSupplyCapped()) {
-            _overlordsBuildRequest.Requested += 1;
-        }
     }
 
     private void MaintainOverlords() {
@@ -64,9 +60,5 @@ public class SupplyManager : UnitlessManager {
 
     private int GetRequestedSupportedSupply() {
         return _overlordsBuildRequest.Requested * SupplyPerOverlord + GetSupplyFromHatcheries();
-    }
-
-    private bool IsSupplyCapped() {
-        return _overlordsBuildRequest.Fulfillment.Remaining == 0 && Controller.IsSupplyCapped;
     }
 }

--- a/Bot/Managers/SupplyManager.cs
+++ b/Bot/Managers/SupplyManager.cs
@@ -15,7 +15,7 @@ public class SupplyManager : UnitlessManager {
     private const int OverlordBatchSize = 4;
 
     private readonly BuildManager _buildManager;
-    private readonly BuildRequest _overlordsBuildRequest = new TargetBuildRequest(BuildType.Train, Units.Overlord, 0);
+    private readonly BuildRequest _overlordsBuildRequest = new TargetBuildRequest(BuildType.Train, Units.Overlord, 0, priority: BuildRequestPriority.High);
     private readonly List<BuildRequest> _buildRequests = new List<BuildRequest>();
 
     public override IEnumerable<BuildFulfillment> BuildFulfillments => _buildRequests.Select(buildRequest => buildRequest.Fulfillment);
@@ -32,8 +32,6 @@ public class SupplyManager : UnitlessManager {
             // TODO GD Be smarter about the batch size
             _overlordsBuildRequest.Requested += OverlordBatchSize;
         }
-
-        _overlordsBuildRequest.Priority = BuildRequestPriority.High;
     }
 
     private void MaintainOverlords() {
@@ -46,7 +44,8 @@ public class SupplyManager : UnitlessManager {
     private bool ShouldTakeOverOverlordManagement() {
         return _buildManager.BuildFulfillments
             .Where(buildFulfilment => buildFulfilment.BuildType == BuildType.Train)
-            .All(buildFulfilment => buildFulfilment.UnitOrUpgradeType != Units.Overlord);
+            .Where(buildFulfilment => buildFulfilment.UnitOrUpgradeType == Units.Overlord)
+            .Sum(buildFulfilment => buildFulfilment.Remaining) <= 0;
     }
 
     private bool ShouldRequestMoreOverlords() {

--- a/Bot/Program.cs
+++ b/Bot/Program.cs
@@ -19,7 +19,7 @@ public class Program {
         //new SpawnStuffScenario(),
     };
 
-    private const string Version = "3_4_0";
+    private const string Version = "3_4_1";
     private static readonly IBot Bot = new SajuukBot(Version, scenarios: Scenarios);
 
     private const string MapFileName = Maps.Season_2022_4.FileNames.Moondance;

--- a/Bot/SajuukBot.cs
+++ b/Bot/SajuukBot.cs
@@ -6,6 +6,7 @@ using Bot.Builds;
 using Bot.Builds.BuildOrders;
 using Bot.Debugging;
 using Bot.ExtensionMethods;
+using Bot.GameData;
 using Bot.GameSense;
 using Bot.Managers;
 using Bot.Managers.EconomyManagement;
@@ -36,6 +37,7 @@ public class SajuukBot: PoliteBot {
 
         var managerRequests = GetManagersBuildRequests();
         var buildBlockStatus = AddressManagerRequests(managerRequests);
+        EnsureNoSupplyBlock();
 
         var flatManagerRequests = managerRequests
             .SelectMany(groupedBySupply => groupedBySupply.SelectMany(request => request))
@@ -173,5 +175,21 @@ public class SajuukBot: PoliteBot {
 
         buildBlockingReason = BuildBlockCondition.None;
         return false;
+    }
+
+    private static void EnsureNoSupplyBlock() {
+        if (!Controller.IsSupplyCapped) {
+            return;
+        }
+
+        if (Controller.GetProducersCarryingOrders(Units.Overlord).Any()) {
+            return;
+        }
+
+        if (Controller.GetProducersCarryingOrders(Units.Hatchery).Any()) {
+            return;
+        }
+
+        Controller.ExecuteBuildStep(new QuantityBuildRequest(BuildType.Train, Units.Overlord).Fulfillment);
     }
 }


### PR DESCRIPTION
# Description
We've had issues where overlords dying early would not be replace, causing an unrecoverable supply cap.  
This was mainly caused by overlord scouts dying to Zerg queens.  

I have also noticed that our first two overlords took the same path because they would scout roughly the same region. In some games, this straight path is not the path ground units take to reach the base and as such, we fail to scout some early aggression.

# What's new
- Added a supply block check in `SajuukBot` to recover from unhandled supply blocks
- The build order now uses `TargetBuildRequest` for overlords instead of `QuantityBuildRequest`
- We now cancel all scouting tasks when we lose a scout to prevent further losses
- Tweaked the scouting order to provide more map vision
  - Instead of scouting the natural and then the base exit, we scout the the natural and the third
  - We make sure that the third is the one closest to the center of the map
- We don't take gas when under 10 drones. This is to prevent sending drones in gas after early drone losses.