### PR TITLE
Feature - Drone mineral walk kiting

### DIFF
--- a/Bot.Tests/ExtensionMethods/Vector2ExtensionsTests.cs
+++ b/Bot.Tests/ExtensionMethods/Vector2ExtensionsTests.cs
@@ -5,7 +5,8 @@ using Bot.Utils;
 namespace Bot.Tests.ExtensionMethods;
 
 public class Vector2ExtensionsTests {
-    private const float RotationPrecision = 0.000002f;
+    private const float RotateAroundPrecision = 0.000002f;
+    private const float AngleToPrecision = 0.00002f;
 
     public static IEnumerable<object[]> AnglesIn360() {
         for (var angle = 0; angle < 360; angle++) {
@@ -26,8 +27,8 @@ public class Vector2ExtensionsTests {
         var rotationMatrix = Matrix4x4.CreateRotationZ((float)MathUtils.DegToRad(angle));
         var expected = Vector2.Transform(pointToRotate, rotationMatrix);
 
-        Assert.InRange(expected.X, actual.X - RotationPrecision, actual.X + RotationPrecision);
-        Assert.InRange(expected.Y, actual.Y - RotationPrecision, actual.Y + RotationPrecision);
+        Assert.InRange(actual.X, expected.X - RotateAroundPrecision, expected.X + RotateAroundPrecision);
+        Assert.InRange(actual.Y, expected.Y - RotateAroundPrecision, expected.Y + RotateAroundPrecision);
     }
 
     [Theory]
@@ -49,7 +50,63 @@ public class Vector2ExtensionsTests {
         expected = Vector2.Transform(expected, rotationMatrix);
         expected = Vector2.Transform(expected, restoreOriginMatrix);
 
-        Assert.InRange(expected.X, actual.X - RotationPrecision, actual.X + RotationPrecision);
-        Assert.InRange(expected.Y, actual.Y - RotationPrecision, actual.Y + RotationPrecision);
+        Assert.InRange(actual.X, expected.X - RotateAroundPrecision, expected.X + RotateAroundPrecision);
+        Assert.InRange(actual.Y, expected.Y - RotateAroundPrecision, expected.Y + RotateAroundPrecision);
+    }
+
+    public static IEnumerable<object[]> Vector2AnglesOrigin() {
+        var origin = new Vector2(0, 0);
+        var pointToRotate = new Vector2(1, 0);
+
+        for (var angle = -360; angle <= 360; angle++) {
+            var radAngle = MathUtils.DegToRad(angle);
+            var expectedRadAngle = MathUtils.DegToRad(
+                angle <= -180 ? angle + 360
+                : angle > 180 ? angle - 360
+                : angle
+            );
+
+            yield return new object[] { origin, pointToRotate.RotateAround(origin, radAngle), expectedRadAngle };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Vector2AnglesOrigin))]
+    public void GivenTheOriginAndAPosition_WhenGetRadAngleTo_ThenReturnsAngleInRadiansBetweenPiIncludedAndMinusPiExcluded(Vector2 origin, Vector2 destination, double expectedRadAngle) {
+        // Act
+        var actualAngle = origin.GetRadAngleTo(destination);
+
+        // Assert
+        Assert.InRange(actualAngle, expectedRadAngle - AngleToPrecision, expectedRadAngle + AngleToPrecision);
+    }
+
+    public static IEnumerable<object[]> Vector2Angles() {
+        var origin = new Vector2(0, 0);
+        var pointToRotate = new Vector2(1, 0);
+
+        for (var angle = -360; angle <= 360; angle++) {
+            var radAngle = MathUtils.DegToRad(angle);
+            var expectedRadAngle = MathUtils.DegToRad(
+                angle <= -180 ? angle + 360
+                : angle > 180 ? angle - 360
+                : angle
+            );
+
+            var offset = new Vector2(angle, angle);
+            var offsetOrigin = origin + offset;
+            var offsetPointToRotate = pointToRotate + offset;
+
+            yield return new object[] { offsetOrigin, offsetPointToRotate.RotateAround(offsetOrigin, radAngle), expectedRadAngle };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Vector2Angles))]
+    public void GivenTwoPositions_WhenGetRadAngleTo_ThenReturnsAngleInRadiansBetweenPiIncludedAndMinusPiExcluded(Vector2 origin, Vector2 destination, double expectedRadAngle) {
+        // Act
+        var actualAngle = origin.GetRadAngleTo(destination);
+
+        // Assert
+        Assert.InRange(actualAngle, expectedRadAngle - AngleToPrecision, expectedRadAngle + AngleToPrecision);
     }
 }

--- a/Bot.Tests/ExtensionMethods/Vector2ExtensionsTests.cs
+++ b/Bot.Tests/ExtensionMethods/Vector2ExtensionsTests.cs
@@ -6,7 +6,7 @@ namespace Bot.Tests.ExtensionMethods;
 
 public class Vector2ExtensionsTests {
     private const float RotateAroundPrecision = 0.000002f;
-    private const float AngleToPrecision = 0.00002f;
+    private const float AngleToPrecision = 0.000001f;
 
     public static IEnumerable<object[]> AnglesIn360() {
         for (var angle = 0; angle < 360; angle++) {

--- a/Bot.Tests/ExtensionMethods/Vector2ExtensionsTests.cs
+++ b/Bot.Tests/ExtensionMethods/Vector2ExtensionsTests.cs
@@ -54,55 +54,24 @@ public class Vector2ExtensionsTests {
         Assert.InRange(actual.Y, expected.Y - RotateAroundPrecision, expected.Y + RotateAroundPrecision);
     }
 
-    public static IEnumerable<object[]> Vector2AnglesOrigin() {
+    public static IEnumerable<object[]> Vector2AtAllAngles() {
         var origin = new Vector2(0, 0);
-        var pointToRotate = new Vector2(1, 0);
+        var vector1 = new Vector2(1, 0);
 
-        for (var angle = -360; angle <= 360; angle++) {
+        for (var angle = 0; angle <= 360; angle++) {
             var radAngle = MathUtils.DegToRad(angle);
-            var expectedRadAngle = MathUtils.DegToRad(
-                angle <= -180 ? angle + 360
-                : angle > 180 ? angle - 360
-                : angle
-            );
 
-            yield return new object[] { origin, pointToRotate.RotateAround(origin, radAngle), expectedRadAngle };
+            var absoluteDegAngle = Math.Abs(angle);
+            var expectedDegAngle = absoluteDegAngle > 180 ? 360 - absoluteDegAngle : absoluteDegAngle;
+            var expectedRadAngle = MathUtils.DegToRad(expectedDegAngle);
+
+            yield return new object[] { vector1, vector1.RotateAround(origin, radAngle), expectedRadAngle };
         }
     }
 
     [Theory]
-    [MemberData(nameof(Vector2AnglesOrigin))]
+    [MemberData(nameof(Vector2AtAllAngles))]
     public void GivenTheOriginAndAPosition_WhenGetRadAngleTo_ThenReturnsAngleInRadiansBetweenPiIncludedAndMinusPiExcluded(Vector2 origin, Vector2 destination, double expectedRadAngle) {
-        // Act
-        var actualAngle = origin.GetRadAngleTo(destination);
-
-        // Assert
-        Assert.InRange(actualAngle, expectedRadAngle - AngleToPrecision, expectedRadAngle + AngleToPrecision);
-    }
-
-    public static IEnumerable<object[]> Vector2Angles() {
-        var origin = new Vector2(0, 0);
-        var pointToRotate = new Vector2(1, 0);
-
-        for (var angle = -360; angle <= 360; angle++) {
-            var radAngle = MathUtils.DegToRad(angle);
-            var expectedRadAngle = MathUtils.DegToRad(
-                angle <= -180 ? angle + 360
-                : angle > 180 ? angle - 360
-                : angle
-            );
-
-            var offset = new Vector2(angle, angle);
-            var offsetOrigin = origin + offset;
-            var offsetPointToRotate = pointToRotate + offset;
-
-            yield return new object[] { offsetOrigin, offsetPointToRotate.RotateAround(offsetOrigin, radAngle), expectedRadAngle };
-        }
-    }
-
-    [Theory]
-    [MemberData(nameof(Vector2Angles))]
-    public void GivenTwoPositions_WhenGetRadAngleTo_ThenReturnsAngleInRadiansBetweenPiIncludedAndMinusPiExcluded(Vector2 origin, Vector2 destination, double expectedRadAngle) {
         // Act
         var actualAngle = origin.GetRadAngleTo(destination);
 

--- a/Bot/Controller.cs
+++ b/Bot/Controller.cs
@@ -76,6 +76,12 @@ public static class Controller {
         ThoseWhoNeedUpdating.ForEach(needsUpdating => needsUpdating.Reset());
     }
 
+    public static void SetSimulationTime(string reason) {
+        _frameDelayMs = 0;
+
+        Chat($"Simulation time set: {reason}", toTeam: true);
+    }
+
     public static void SetRealTime(string reason) {
         _frameDelayMs = RealTime;
 

--- a/Bot/ExtensionMethods/Vector2Extensions.cs
+++ b/Bot/ExtensionMethods/Vector2Extensions.cs
@@ -266,24 +266,13 @@ public static class Vector2Extensions {
     }
 
     /// <summary>
-    /// Calculates the angle from origin to destination with respect to (1, 0).
+    /// Calculates the angle between two vectors
     /// The angle is going to be within ]-PI, PI].
     /// </summary>
-    /// <param name="origin">The origin of the vector</param>
-    /// <param name="destination">The end of the vector</param>
-    /// <returns>The angle in rad between (1, 0) and (origin, destination) within ]-PI, PI]</returns>
-    public static double GetRadAngleTo(this Vector2 origin, Vector3 destination) {
-        return origin.GetRadAngleTo(destination.ToVector2());
-    }
-
-    /// <summary>
-    /// Calculates the angle from origin to destination with respect to (1, 0).
-    /// The angle is going to be within ]-PI, PI].
-    /// </summary>
-    /// <param name="origin">The origin of the vector</param>
-    /// <param name="destination">The end of the vector</param>
-    /// <returns>The angle in rad between (1, 0) and (origin, destination) within ]-PI, PI]</returns>
-    public static double GetRadAngleTo(this Vector2 origin, Vector2 destination) {
-        return Math.Atan2(destination.Y - origin.Y, destination.X - origin.X);
+    /// <param name="v1">The first vector</param>
+    /// <param name="v2">The second vector</param>
+    /// <returns>The angle in rad between the two vectors within ]-PI, PI]</returns>
+    public static double GetRadAngleTo(this Vector2 v1, Vector2 v2) {
+        return Math.Acos(Vector2.Dot(v1, v2) / (v1.Length() * v2.Length()));
     }
 }

--- a/Bot/ExtensionMethods/Vector2Extensions.cs
+++ b/Bot/ExtensionMethods/Vector2Extensions.cs
@@ -225,6 +225,16 @@ public static class Vector2Extensions {
     /// <param name="origin">The origin</param>
     /// <param name="destination">The destination to look at</param>
     /// <returns>A normal vector that represents a direction vector from the origin towards the destination</returns>
+    public static Vector2 DirectionTo(this Vector2 origin, Vector3 destination) {
+        return origin.DirectionTo(destination.ToVector2());
+    }
+
+    /// <summary>
+    /// Calculates a normal vector that represents a direction vector from the origin towards the destination
+    /// </summary>
+    /// <param name="origin">The origin</param>
+    /// <param name="destination">The destination to look at</param>
+    /// <returns>A normal vector that represents a direction vector from the origin towards the destination</returns>
     public static Vector2 DirectionTo(this Vector2 origin, Vector2 destination) {
         return Vector2.Normalize(destination - origin);
     }
@@ -253,5 +263,27 @@ public static class Vector2Extensions {
         var direction = origin.DirectionTo(destination);
 
         return origin - direction * distance;
+    }
+
+    /// <summary>
+    /// Calculates the angle from origin to destination with respect to (1, 0).
+    /// The angle is going to be within ]-PI, PI].
+    /// </summary>
+    /// <param name="origin">The origin of the vector</param>
+    /// <param name="destination">The end of the vector</param>
+    /// <returns>The angle in rad between (1, 0) and (origin, destination) within ]-PI, PI]</returns>
+    public static double GetRadAngleTo(this Vector2 origin, Vector3 destination) {
+        return origin.GetRadAngleTo(destination.ToVector2());
+    }
+
+    /// <summary>
+    /// Calculates the angle from origin to destination with respect to (1, 0).
+    /// The angle is going to be within ]-PI, PI].
+    /// </summary>
+    /// <param name="origin">The origin of the vector</param>
+    /// <param name="destination">The end of the vector</param>
+    /// <returns>The angle in rad between (1, 0) and (origin, destination) within ]-PI, PI]</returns>
+    public static double GetRadAngleTo(this Vector2 origin, Vector2 destination) {
+        return Math.Atan2(destination.Y - origin.Y, destination.X - origin.X);
     }
 }

--- a/Bot/Managers/WarManagement/ArmySupervision/AttackState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/AttackState.cs
@@ -87,8 +87,7 @@ public partial class ArmySupervisor {
 
             DrawAttackData(targetToAttack, army);
 
-            // TODO GD "IsIdleOrMovingOrAttacking || IsMineralWalking" is kinda whack because it knows about drone behaviour
-            var unitsToAttackWith = army.Where(unit => unit.IsIdleOrMovingOrAttacking() || unit.IsMineralWalking())
+            var unitsToAttackWith = army.Where(unit => unit.IsIdle() || unit.IsMoving() || unit.IsAttacking() || unit.IsMineralWalking())
                 .Where(unit => !unit.IsBurrowed)
                 .Where(unit => unit.DistanceTo(targetToAttack) > AcceptableDistanceToTarget)
                 .ToList();

--- a/Bot/Managers/WarManagement/ArmySupervision/AttackState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/AttackState.cs
@@ -6,11 +6,11 @@ using Bot.Debugging.GraphicalDebugging;
 using Bot.ExtensionMethods;
 using Bot.GameData;
 using Bot.GameSense;
-using Bot.Managers.WarManagement.ArmySupervision.Tactics;
+using Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
+using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 using Bot.MapKnowledge;
 using Bot.StateManagement;
 using Bot.Utils;
-using SneakAttackTactic = Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack.SneakAttackTactic;
 
 namespace Bot.Managers.WarManagement.ArmySupervision;
 
@@ -28,14 +28,14 @@ public partial class ArmySupervisor {
         private ulong _pathfindingLock = 0;
         private ulong _pathfindingLockDelay = TimeUtils.SecsToFrames(4);
 
-        private readonly ITactic _sneakAttackTactic = new SneakAttackTactic();
+        private readonly IUnitsControl _sneakAttackUnitsControl = new SneakAttackUnitsControl();
 
         protected override void OnTransition() {
-            _sneakAttackTactic.Reset(null);
+            _sneakAttackUnitsControl.Reset(null);
         }
 
         protected override bool TryTransitioning() {
-            if (_sneakAttackTactic.IsExecuting()) {
+            if (_sneakAttackUnitsControl.IsExecuting()) {
                 return false;
             }
 
@@ -52,11 +52,11 @@ public partial class ArmySupervisor {
 
             DrawArmyData(Context._mainArmy);
 
-            if (_sneakAttackTactic.IsViable(Context._mainArmy)) {
-                _sneakAttackTactic.Execute(Context._mainArmy);
+            if (_sneakAttackUnitsControl.IsViable(Context._mainArmy)) {
+                _sneakAttackUnitsControl.Execute(Context._mainArmy);
             }
             else {
-                _sneakAttackTactic.Reset(Context._mainArmy);
+                _sneakAttackUnitsControl.Reset(Context._mainArmy);
                 Attack(Context._target, Context._mainArmy);
             }
 

--- a/Bot/Managers/WarManagement/ArmySupervision/DefenseState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/DefenseState.cs
@@ -79,7 +79,7 @@ public partial class ArmySupervisor {
                 .ToList();
 
             if (targetList.Any()) {
-                soldiers.Where(unit => unit.IsIdle() || unit.IsMoving() || unit.IsAttacking())
+                soldiers.Where(unit => unit.IsIdle() || unit.IsMoving() || unit.IsAttacking() || unit.IsMineralWalking())
                     .Where(unit => !unit.IsBurrowed)
                     .ToList()
                     .ForEach(soldier => {

--- a/Bot/Managers/WarManagement/ArmySupervision/DefenseState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/DefenseState.cs
@@ -65,7 +65,7 @@ public partial class ArmySupervisor {
                 .ToList();
 
             if (targetList.Any()) {
-                soldiers.Where(unit => unit.IsIdleOrMovingOrAttacking())
+                soldiers.Where(unit => unit.IsIdle() || unit.IsMoving() || unit.IsAttacking())
                     .Where(unit => !unit.IsBurrowed)
                     .ToList()
                     .ForEach(soldier => {

--- a/Bot/Managers/WarManagement/ArmySupervision/HuntState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/HuntState.cs
@@ -60,10 +60,6 @@ public partial class ArmySupervisor {
             AssignNewTarget();
         }
 
-        private static bool AllLocationsHaveBeenChecked(Dictionary<Vector3, bool> locations) {
-            return locations.Values.All(isChecked => isChecked);
-        }
-
         private static bool AllLocationsHaveBeenChecked(Dictionary<Vector2, bool> locations) {
             return locations.Values.All(isChecked => isChecked);
         }

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using Bot.ExtensionMethods;
 using Bot.GameData;
 using Bot.GameSense;
@@ -28,23 +29,9 @@ public class DroneKitingUnitsControl : IUnitsControl {
         }
 
         var regimentCenter = Clustering.GetCenter(dronesThatNeedToKite);
-        var regimentRegion = regimentCenter.GetRegion();
 
-        var regimentRegionExits = regimentRegion.GetReachableNeighbors();
-        var mineralFields = regimentRegionExits.SelectMany(regimentRegionExit => {
-            // TODO GD We can reduce the amount of mineral fields by returning only 1 if we need to go through an exit
-            // TODO GD We should also consider the location of such minerals fields to be the exit region, since we'll route through there
-            var expandLocation = GetExpandLocationGoingThroughExit(regimentRegion, regimentRegionExit);
-            if (expandLocation != null) {
-                return expandLocation.ResourceCluster.Where(resource => Units.MineralFields.Contains(resource.UnitType));
-            }
-
-            return Enumerable.Empty<Unit>();
-        })
-            .ToList();
-
-        // No mineral fields to walk to, we can't act.
-        if (mineralFields.Count <= 0) {
+        var candidateMineralFields = GetMineralFieldsToWalkTo(regimentCenter);
+        if (candidateMineralFields.Count <= 0) {
             return uncontrolledUnits;
         }
 
@@ -61,7 +48,7 @@ public class DroneKitingUnitsControl : IUnitsControl {
             }
 
             var enemiesToAvoid = potentialEnemiesToAvoid.Where(enemy => enemy.DistanceTo(regimentCenter) <= 5).ToList();
-            var mineralToWalkTo = GetMineralToWalkTo(drone, enemiesToAvoid, mineralFields);
+            var mineralToWalkTo = GetMineralFieldToWalkTo(drone, enemiesToAvoid, candidateMineralFields);
 
             if (mineralToWalkTo != null) {
                 drone.Gather(mineralToWalkTo);
@@ -105,13 +92,52 @@ public class DroneKitingUnitsControl : IUnitsControl {
     }
 
     /// <summary>
+    /// Find all mineral fields that can be used to mineral walk.
+    /// - Those in the current region
+    /// - One patch per exit from the current region
+    ///
+    /// We will return a list of tuples composed of the mineral field and a position representing the exit that the unit would go through when going to that mineral field.
+    /// In the case of mineral fields in the same region as the regimentPosition, their exit will be themselves because the unit won't be funneled through an exit.
+    /// </summary>
+    /// <param name="regimentPosition">Where the regiment currently is</param>
+    /// <returns>A list of tuples composed of the mineral field and a position representing the exit that the unit would go through when going to that mineral field.</returns>
+    private static List<(Unit unit, Vector2 exit)> GetMineralFieldsToWalkTo(Vector2 regimentPosition) {
+        var regimentRegion = regimentPosition.GetRegion();
+        var regimentRegionExits = regimentRegion.GetReachableNeighbors();
+
+        return regimentRegionExits.SelectMany(regimentRegionExit => {
+                var expandLocation = GetExpandLocationGoingThroughExit(regimentRegion, regimentRegionExit);
+                if (expandLocation == null) {
+                    return Enumerable.Empty<(Unit, Vector2)>();
+                }
+
+                // When the region is the regimentRegion, we return all minerals with their own position as exit.
+                // We keep all minerals because each of them will likely be in a different direction from the unit.
+                if (regimentRegionExit == regimentRegion) {
+                    return expandLocation.ResourceCluster
+                        .Where(resource => Units.MineralFields.Contains(resource.UnitType))
+                        .Select(resource => (resource, resource.Position.ToVector2()));
+                }
+
+                // When the region is not the regimentRegion, it means we'll have to go through an exit to get to the mineral field.
+                // Because of this, all minerals will more or less create the same path to that exit.
+                // The initial movement is going to be hard to accurately determine, so we'll use the center of the exit as an estimation.
+                var resource = expandLocation.ResourceCluster
+                    .First(resource => Units.MineralFields.Contains(resource.UnitType));
+
+                return new List<(Unit, Vector2)> { (resource, regimentRegionExit.Center) };
+            })
+            .ToList();
+    }
+
+    /// <summary>
     /// Gets the mineral from mineralFields that the given drone should to walk to in order to avoid enemiesToAvoid.
     /// </summary>
     /// <param name="drone">The drone that needs to run</param>
     /// <param name="enemiesToAvoid">The enemies that need to be avoided</param>
     /// <param name="mineralFields">The mineral fields we can walk to</param>
     /// <returns>The mineral field to walk to, or null if there are no good choices</returns>
-    private static Unit GetMineralToWalkTo(Unit drone, IReadOnlyCollection<Unit> enemiesToAvoid, IEnumerable<Unit> mineralFields) {
+    private static Unit GetMineralFieldToWalkTo(Unit drone, IReadOnlyCollection<Unit> enemiesToAvoid, IEnumerable<(Unit unit, Vector2 exit)> mineralFields) {
         if (enemiesToAvoid.Count <= 0) {
             return null;
         }
@@ -122,18 +148,18 @@ public class DroneKitingUnitsControl : IUnitsControl {
 
         // Find the mineral field with the angle closest to enemy-drone (angle 0 = directly fleeing the enemy
         var mineralToWalkTo = mineralFields.MinBy(mineralField => {
-            var mineralVector = drone.Position.DirectionTo(mineralField.Position);
+            var mineralVector = drone.Position.ToVector2().DirectionTo(mineralField.exit);
 
             return Math.Abs(enemyVector.GetRadAngleTo(mineralVector));
         });
 
-        var mineralVector = drone.Position.DirectionTo(mineralToWalkTo.Position);
+        var mineralVector = drone.Position.ToVector2().DirectionTo(mineralToWalkTo.exit);
         var mineralAngle = Math.Abs(enemyVector.GetRadAngleTo(mineralVector));
         if (mineralAngle > MathUtils.DegToRad(90)) {
             // If the best we got sends us towards the enemy, we don't do it
             return null;
         }
 
-        return mineralToWalkTo;
+        return mineralToWalkTo.unit;
     }
 }

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bot.ExtensionMethods;
+using Bot.GameData;
+using Bot.GameSense;
+using Bot.MapKnowledge;
+using Bot.Utils;
+
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
+
+public class DroneKitingUnitsControl : IUnitsControl {
+    public bool IsExecuting() {
+        // No state, we can abort anytime
+        return false;
+    }
+
+    public IReadOnlySet<Unit> Execute(IReadOnlySet<Unit> army) {
+        var uncontrolledUnits = new HashSet<Unit>(army);
+
+        var dronesThatNeedToKite = army
+            .Where(unit => unit.UnitType == Units.Drone)
+            .Where(drone => drone.RawUnitData.WeaponCooldown > 0)
+            .ToHashSet();
+
+        if (dronesThatNeedToKite.Count == 0) {
+            return uncontrolledUnits;
+        }
+
+        var regimentCenter = Clustering.GetCenter(dronesThatNeedToKite);
+        var regimentRegion = regimentCenter.GetRegion();
+
+        var regimentRegionExits = regimentRegion.GetReachableNeighbors();
+        var mineralFields = regimentRegionExits.SelectMany(regimentRegionExit => {
+            // TODO GD We can reduce the amount of mineral fields by returning only 1 if we need to go through an exit
+            // TODO GD We should also consider the location of such minerals fields to be the exit region, since we'll route through there
+            var expandLocation = GetExpandLocationGoingThroughExit(regimentRegion, regimentRegionExit);
+            if (expandLocation != null) {
+                return expandLocation.ResourceCluster.Where(resource => Units.MineralFields.Contains(resource.UnitType));
+            }
+
+            return Enumerable.Empty<Unit>();
+        })
+            .ToList();
+
+        // No mineral fields to walk to, we can't act.
+        if (mineralFields.Count <= 0) {
+            return uncontrolledUnits;
+        }
+
+        // Filter out some enemies for performance
+        var potentialEnemiesToAvoid = UnitsTracker.EnemyUnits.Where(enemy => enemy.DistanceTo(regimentCenter) <= 20).ToList();
+        if (potentialEnemiesToAvoid.Count <= 0) {
+            return uncontrolledUnits;
+        }
+
+        foreach (var drone in dronesThatNeedToKite) {
+            if (drone.IsMineralWalking()) {
+                uncontrolledUnits.Remove(drone);
+                continue;
+            }
+
+            var enemiesToAvoid = potentialEnemiesToAvoid.Where(enemy => enemy.DistanceTo(regimentCenter) <= 5).ToList();
+            var mineralToWalkTo = GetMineralToWalkTo(drone, enemiesToAvoid, mineralFields);
+
+            if (mineralToWalkTo != null) {
+                drone.Gather(mineralToWalkTo);
+                uncontrolledUnits.Remove(drone);
+            }
+        }
+
+        return uncontrolledUnits;
+    }
+
+    public void Reset(IReadOnlyCollection<Unit> army) {
+        // No state, aborting is instantaneous
+    }
+
+    /// <summary>
+    /// Gets an first non depleted expand that will route through the exist from the origin.
+    /// Returns null if none were found.
+    /// </summary>
+    /// <param name="origin">The origin of the exit</param>
+    /// <param name="exit">The exit to go through</param>
+    /// <returns>An expand whose path from the origin goes through the exit, or null if none.</returns>
+    private static ExpandLocation GetExpandLocationGoingThroughExit(Region origin, Region exit) {
+        var exploredRegions = new HashSet<Region> { origin };
+        var regionsToExplore = new Queue<Region>();
+        regionsToExplore.Enqueue(exit);
+
+        while (regionsToExplore.Count > 0) {
+            var regionToExplore = regionsToExplore.Dequeue();
+            exploredRegions.Add(regionToExplore);
+
+            if (regionToExplore.Type == RegionType.Expand && !regionToExplore.ExpandLocation.IsDepleted) {
+                return regionToExplore.ExpandLocation;
+            }
+
+            foreach (var neighbor in regionToExplore.GetReachableNeighbors().Where(neighbor => !exploredRegions.Contains(neighbor))) {
+                regionsToExplore.Enqueue(neighbor);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the mineral from mineralFields that the given drone should to walk to in order to avoid enemiesToAvoid.
+    /// </summary>
+    /// <param name="drone">The drone that needs to run</param>
+    /// <param name="enemiesToAvoid">The enemies that need to be avoided</param>
+    /// <param name="mineralFields">The mineral fields we can walk to</param>
+    /// <returns>The mineral field to walk to, or null if there are no good choices</returns>
+    private static Unit GetMineralToWalkTo(Unit drone, IReadOnlyCollection<Unit> enemiesToAvoid, IEnumerable<Unit> mineralFields) {
+        if (enemiesToAvoid.Count <= 0) {
+            return null;
+        }
+
+        // Get the enemy-drone angle
+        var enemiesCenter = Clustering.GetCenter(enemiesToAvoid);
+        var enemyVector = enemiesCenter.DirectionTo(drone.Position);
+
+        // Find the mineral field with the angle closest to enemy-drone (angle 0 = directly fleeing the enemy
+        var mineralToWalkTo = mineralFields.MinBy(mineralField => {
+            var mineralVector = drone.Position.DirectionTo(mineralField.Position);
+
+            return Math.Abs(enemyVector.GetRadAngleTo(mineralVector));
+        });
+
+        var mineralVector = drone.Position.DirectionTo(mineralToWalkTo.Position);
+        var mineralAngle = Math.Abs(enemyVector.GetRadAngleTo(mineralVector));
+        if (mineralAngle > MathUtils.DegToRad(90)) {
+            // If the best we got sends us towards the enemy, we don't do it
+            return null;
+        }
+
+        return mineralToWalkTo;
+    }
+}

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
@@ -21,7 +21,7 @@ public class DroneKitingUnitsControl : IUnitsControl {
     public IReadOnlySet<Unit> Execute(IReadOnlySet<Unit> army) {
         var uncontrolledUnits = new HashSet<Unit>(army);
 
-        var droneMaximumWeaponCooldown = KnowledgeBase.GetUnitTypeData(Units.Drone).Weapons[0].Speed; // Speed in frames
+        var droneMaximumWeaponCooldown = KnowledgeBase.GetUnitTypeData(Units.Drone).Weapons[0].Speed * TimeUtils.FramesPerSecond; // Speed is in seconds between attacks
         var dronesThatNeedToKite = army
             .Where(unit => unit.UnitType == Units.Drone)
             // We mineral walk for a duration of 75% of the weapon cooldown.

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/DroneKitingUnitsControl.cs
@@ -36,7 +36,12 @@ public class DroneKitingUnitsControl : IUnitsControl {
             return uncontrolledUnits;
         }
 
-        var candidateMineralFields = GetMineralFieldsToWalkTo(dronesThatNeedToKite.GetRegion());
+        var regimentRegion = dronesThatNeedToKite.GetRegion();
+        if (regimentRegion == null) {
+            return uncontrolledUnits;
+        }
+
+        var candidateMineralFields = GetMineralFieldsToWalkTo(regimentRegion);
         if (candidateMineralFields.Count <= 0) {
             return uncontrolledUnits;
         }

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/IUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/IUnitsControl.cs
@@ -3,11 +3,15 @@
 namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
 
 public interface IUnitsControl {
-    bool IsViable(IReadOnlyCollection<Unit> army);
-
     bool IsExecuting();
 
-    void Execute(IReadOnlyCollection<Unit> army);
+    // TODO GD Profile performance of mutating the hashset vs returning a new one
+    /// <summary>
+    /// Executes the units control.
+    /// Units that are controlled will be removed from the army.
+    /// </summary>
+    /// <param name="army"></param>
+    IReadOnlySet<Unit> Execute(IReadOnlySet<Unit> army);
 
     void Reset(IReadOnlyCollection<Unit> army);
 }

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/IUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/IUnitsControl.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
 
-public interface ITactic {
+public interface IUnitsControl {
     bool IsViable(IReadOnlyCollection<Unit> army);
 
     bool IsExecuting();

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/MineralWalkKiting.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/MineralWalkKiting.cs
@@ -12,7 +12,7 @@ using SC2APIProtocol;
 
 namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
 
-public class DroneKitingUnitsControl : IUnitsControl {
+public class MineralWalkKiting : IUnitsControl {
     public bool IsExecuting() {
         // No state, we can abort anytime
         return false;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
@@ -3,9 +3,9 @@ using System.Linq;
 using Bot.ExtensionMethods;
 using Bot.GameSense;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public partial class SneakAttackTactic {
+public partial class SneakAttackUnitsControl {
     public class ApproachState : SneakAttackState {
         private const float SetupDistance = 1.25f;
 

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
@@ -3,9 +3,9 @@ using System.Linq;
 using Bot.ExtensionMethods;
 using Bot.GameSense;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public partial class SneakAttackUnitsControl {
+public partial class SneakAttack {
     public class ApproachState : SneakAttackState {
         private const float SetupDistance = 1.25f;
 

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
@@ -60,7 +60,7 @@ public partial class SneakAttackUnitsControl {
             BurrowOverlings(Context._army);
 
             if (Context._targetPosition.DistanceTo(Context._armyCenter) > SetupDistance) {
-                foreach (var soldier in Context._army.Where(soldier => soldier.IsIdleOrMovingOrAttacking())) {
+                foreach (var soldier in Context._army.Where(soldier => soldier.IsIdle() || soldier.IsMoving() || soldier.IsAttacking())) {
                     soldier.Move(Context._targetPosition);
                 }
             }

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/ApproachState.cs
@@ -9,10 +9,17 @@ public partial class SneakAttackUnitsControl {
     public class ApproachState : SneakAttackState {
         private const float SetupDistance = 1.25f;
 
+        private const float OperationRadius = TankRange + 5;
+
         private readonly StuckDetector _stuckDetector = new StuckDetector();
 
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             if (DetectionTracker.IsDetected(army)) {
+                return false;
+            }
+
+            var priorityTargets = GetPriorityTargetsInOperationRadius(army, OperationRadius);
+            if (!priorityTargets.Any()) {
                 return false;
             }
 
@@ -29,7 +36,7 @@ public partial class SneakAttackUnitsControl {
                 return;
             }
 
-            var closestPriorityTarget = GetPriorityTargetsInOperationRadius(Context._armyCenter).MinBy(enemy => enemy.DistanceTo(Context._armyCenter));
+            var closestPriorityTarget = GetPriorityTargetsInOperationRadius(Context._army, OperationRadius).MinBy(enemy => enemy.DistanceTo(Context._armyCenter));
             if (closestPriorityTarget != null) {
                 Context._targetPosition = closestPriorityTarget.Position.ToVector2();
                 Context._isTargetPriority = true;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/EngageState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/EngageState.cs
@@ -2,9 +2,9 @@
 using System.Linq;
 using Bot.GameData;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public partial class SneakAttackTactic {
+public partial class SneakAttackUnitsControl {
     public class EngageState : SneakAttackState {
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             return true;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/EngageState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/EngageState.cs
@@ -2,9 +2,9 @@
 using System.Linq;
 using Bot.GameData;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public partial class SneakAttackUnitsControl {
+public partial class SneakAttack {
     public class EngageState : SneakAttackState {
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             return true;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/InactiveState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/InactiveState.cs
@@ -4,9 +4,9 @@ using Bot.ExtensionMethods;
 using Bot.GameData;
 using Bot.GameSense;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public partial class SneakAttackTactic {
+public partial class SneakAttackUnitsControl {
     public class InactiveState: SneakAttackState {
         private const float MinimumEngagementArmyThreshold = 0.75f;
         private const float OverwhelmingForceRatio = 4f;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/InactiveState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/InactiveState.cs
@@ -4,9 +4,9 @@ using Bot.ExtensionMethods;
 using Bot.GameData;
 using Bot.GameSense;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public partial class SneakAttackUnitsControl {
+public partial class SneakAttack {
     public class InactiveState: SneakAttackState {
         private const float MinimumEngagementArmyThreshold = 0.75f;
         private const float OverwhelmingForceRatio = 4f;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/InactiveState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/InactiveState.cs
@@ -11,6 +11,8 @@ public partial class SneakAttackUnitsControl {
         private const float MinimumEngagementArmyThreshold = 0.75f;
         private const float OverwhelmingForceRatio = 4f;
 
+        private const float OperationRadius = TankRange + 3;
+
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             if (Context._coolDownUntil > Controller.Frame) {
                 return false;
@@ -20,11 +22,9 @@ public partial class SneakAttackUnitsControl {
                 return false;
             }
 
-            // TODO GD Should probably weight this in when doing the other checks instead of returning true
-            var priorityTargets = GetPriorityTargetsInOperationRadius(army.GetCenter());
-            if (priorityTargets.Any()) {
-                // F*ck em up!
-                return true;
+            var priorityTargets = GetPriorityTargetsInOperationRadius(army, OperationRadius);
+            if (!priorityTargets.Any()) {
+                return false;
             }
 
             var enemiesInSightOfTheArmy = GetGroundEnemiesInSight(army).ToList();
@@ -43,7 +43,6 @@ public partial class SneakAttackUnitsControl {
                 .ToList();
 
             var nbSoldiersInRange = army.Count(soldier => enemyMilitaryUnits.Any(soldier.IsInAttackRangeOf));
-
             if (nbSoldiersInRange >= army.Count * MinimumEngagementArmyThreshold) {
                 // We have a pretty good engagement already
                 return false;
@@ -53,7 +52,7 @@ public partial class SneakAttackUnitsControl {
         }
 
         protected override void Execute() {
-            var closestPriorityTarget = GetPriorityTargetsInOperationRadius(Context._armyCenter).MinBy(enemy => enemy.DistanceTo(Context._armyCenter));
+            var closestPriorityTarget = GetPriorityTargetsInOperationRadius(Context._army, OperationRadius).MinBy(enemy => enemy.DistanceTo(Context._armyCenter));
             if (closestPriorityTarget != null) {
                 Context._targetPosition = closestPriorityTarget.Position.ToVector2();
                 Context._isTargetPriority = true;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SetupState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SetupState.cs
@@ -5,9 +5,9 @@ using Bot.GameData;
 using Bot.GameSense;
 using Bot.UnitModules;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public partial class SneakAttackTactic {
+public partial class SneakAttackUnitsControl {
     public class SetupState : SneakAttackState {
         private const float EngageDistance = 1f;
         private const float MinimumArmyThresholdToEngage = 0.80f;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SetupState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SetupState.cs
@@ -13,10 +13,17 @@ public partial class SneakAttackUnitsControl {
         private const float MinimumArmyThresholdToEngage = 0.80f;
         private const double MinimumIntegrityToEngage = BurrowMicroModule.BurrowDownThreshold + 0.1;
 
+        private const float OperationRadius = TankRange - 5;
+
         private readonly StuckDetector _stuckDetector = new StuckDetector();
 
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             if (DetectionTracker.IsDetected(army)) {
+                return false;
+            }
+
+            var priorityTargets = GetPriorityTargetsInOperationRadius(army, OperationRadius);
+            if (!priorityTargets.Any()) {
                 return false;
             }
 
@@ -58,7 +65,7 @@ public partial class SneakAttackUnitsControl {
 
         private void ComputeTargetPosition() {
             // Do we need _isTargetPriority at this point? We shouldn't lose sight at this point, right?
-            var closestPriorityTarget = GetPriorityTargetsInOperationRadius(Context._armyCenter)
+            var closestPriorityTarget = GetPriorityTargetsInOperationRadius(Context._army, OperationRadius)
                 .MinBy(enemy => enemy.DistanceTo(Context._armyCenter));
 
             if (closestPriorityTarget != null) {

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SetupState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SetupState.cs
@@ -5,9 +5,9 @@ using Bot.GameData;
 using Bot.GameSense;
 using Bot.UnitModules;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public partial class SneakAttackUnitsControl {
+public partial class SneakAttack {
     public class SetupState : SneakAttackState {
         private const float EngageDistance = 1f;
         private const float MinimumArmyThresholdToEngage = 0.80f;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttack.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttack.cs
@@ -10,12 +10,12 @@ using Bot.StateManagement;
 using Bot.UnitModules;
 using Bot.Utils;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public partial class SneakAttackUnitsControl: IWatchUnitsDie, IUnitsControl {
+public partial class SneakAttack: IWatchUnitsDie, IUnitsControl {
     private const float TankRange = 13;
 
-    private readonly StateMachine<SneakAttackUnitsControl, SneakAttackState> _stateMachine;
+    private readonly StateMachine<SneakAttack, SneakAttackState> _stateMachine;
     private readonly HashSet<Unit> _unitsWithUninstalledModule = new HashSet<Unit>();
     private Vector2 _targetPosition;
     private bool _isTargetPriority = false;
@@ -33,8 +33,8 @@ public partial class SneakAttackUnitsControl: IWatchUnitsDie, IUnitsControl {
         Units.Immortal,
     };
 
-    public SneakAttackUnitsControl() {
-        _stateMachine = new StateMachine<SneakAttackUnitsControl, SneakAttackState>(this, new InactiveState());
+    public SneakAttack() {
+        _stateMachine = new StateMachine<SneakAttack, SneakAttackState>(this, new InactiveState());
     }
 
     public bool IsExecuting() {

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttackState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttackState.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using Bot.StateManagement;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public abstract class SneakAttackState: State<SneakAttackTactic> {
+public abstract class SneakAttackState: State<SneakAttackUnitsControl> {
     protected SneakAttackState NextState = null;
 
     public abstract bool IsViable(IReadOnlyCollection<Unit> army);

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttackState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttackState.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using Bot.StateManagement;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public abstract class SneakAttackState: State<SneakAttackUnitsControl> {
+public abstract class SneakAttackState: State<SneakAttack> {
     protected SneakAttackState NextState = null;
 
     public abstract bool IsViable(IReadOnlyCollection<Unit> army);

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttackUnitsControl.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/SneakAttackUnitsControl.cs
@@ -10,13 +10,13 @@ using Bot.StateManagement;
 using Bot.UnitModules;
 using Bot.Utils;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public partial class SneakAttackTactic: IWatchUnitsDie, ITactic {
+public partial class SneakAttackUnitsControl: IWatchUnitsDie, IUnitsControl {
     private const float TankRange = 13;
     private const float OperationRadius = TankRange + 2;
 
-    private readonly StateMachine<SneakAttackTactic, SneakAttackState> _stateMachine;
+    private readonly StateMachine<SneakAttackUnitsControl, SneakAttackState> _stateMachine;
     private readonly HashSet<Unit> _unitsWithUninstalledModule = new HashSet<Unit>();
     private Vector2 _targetPosition;
     private bool _isTargetPriority = false;
@@ -34,8 +34,8 @@ public partial class SneakAttackTactic: IWatchUnitsDie, ITactic {
         Units.Immortal,
     };
 
-    public SneakAttackTactic() {
-        _stateMachine = new StateMachine<SneakAttackTactic, SneakAttackState>(this, new InactiveState());
+    public SneakAttackUnitsControl() {
+        _stateMachine = new StateMachine<SneakAttackUnitsControl, SneakAttackState>(this, new InactiveState());
     }
 
     public bool IsViable(IReadOnlyCollection<Unit> army) {

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/TerminalState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/TerminalState.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
-public partial class SneakAttackUnitsControl {
+public partial class SneakAttack {
     public class TerminalState: SneakAttackState {
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             return false;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/TerminalState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttack/TerminalState.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace Bot.Managers.WarManagement.ArmySupervision.Tactics.SneakAttack;
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
 
-public partial class SneakAttackTactic {
+public partial class SneakAttackUnitsControl {
     public class TerminalState: SneakAttackState {
         public override bool IsViable(IReadOnlyCollection<Unit> army) {
             return false;

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/UnitsController.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/UnitsController.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 
 namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
 
 public class UnitsController : IUnitsControl {
     private readonly List<IUnitsControl> _unitsControls = new List<IUnitsControl>
     {
-        new DroneKitingUnitsControl(),
-        new SneakAttackUnitsControl(),
+        new MineralWalkKiting(),
+        new SneakAttack(),
     };
 
     public bool IsExecuting() {

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/UnitsController.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/UnitsController.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttack;
+
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
+
+public class UnitsController : IUnitsControl {
+    private readonly List<IUnitsControl> _unitsControls = new List<IUnitsControl>
+    {
+        new DroneKitingUnitsControl(),
+        new SneakAttackUnitsControl(),
+    };
+
+    public bool IsExecuting() {
+        return _unitsControls.Any(unitsControl => unitsControl.IsExecuting());
+    }
+
+    public IReadOnlySet<Unit> Execute(IReadOnlySet<Unit> army) {
+        return _unitsControls.Aggregate(army, (remainingArmy, unitsControl) => unitsControl.Execute(remainingArmy));
+    }
+
+    public void Reset(IReadOnlyCollection<Unit> army) {
+        _unitsControls.ForEach(unitsControl => unitsControl.Reset(army));
+    }
+}

--- a/Bot/Program.cs
+++ b/Bot/Program.cs
@@ -19,7 +19,7 @@ public class Program {
         //new SpawnStuffScenario(),
     };
 
-    private const string Version = "3_4_2";
+    private const string Version = "3_5_0";
     private static readonly IBot Bot = new SajuukBot(Version, scenarios: Scenarios);
 
     private const string MapFileName = Maps.Season_2022_4.FileNames.Moondance;

--- a/Bot/Scenarios/WorkerRushScenario.cs
+++ b/Bot/Scenarios/WorkerRushScenario.cs
@@ -1,18 +1,16 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Bot.ExtensionMethods;
 using Bot.GameData;
-using Bot.GameSense;
 using Bot.MapKnowledge;
 using Bot.Utils;
 using Bot.Wrapper;
+using SC2APIProtocol;
 
 namespace Bot.Scenarios;
 
 // Simulates a worker rush by smallBly https://aiarena.net/bots/338/
 public class WorkerRushScenario: IScenario {
-    private const int DefaultTimingInSeconds = 1 * 60 + 50;
-    private const int SpawnDistance = 4; // Must be in aggro range otherwise they run away
+    private const int DefaultTimingInSeconds = 50;
 
     private readonly int _timingInSeconds;
     private bool _isScenarioDone = false;
@@ -27,15 +25,12 @@ public class WorkerRushScenario: IScenario {
         }
 
         if (Controller.Frame >= TimeUtils.SecsToFrames(_timingInSeconds)) {
-            var natural = Controller.GetUnits(UnitsTracker.OwnedUnits, Units.TownHalls)
-                .MinBy(townHall => Pathfinder.FindPath(townHall.Position.ToVector2(), MapAnalyzer.EnemyStartingLocation).Count);
+            var mainPosition = ExpandAnalyzer.GetExpand(Alliance.Self, ExpandType.Main).Position;
 
-            var pathFromNatural = Pathfinder.FindPath(natural!.Position.ToVector2(), MapAnalyzer.EnemyStartingLocation);
-
-            Logger.Debug("Spawning 12 zerglings {0} units away from natural", pathFromNatural[SpawnDistance].DistanceTo(natural));
+            Logger.Debug("Spawning 12 zerglings {0} units away from main", 0);
 
             // Spawned drones wouldn't be aggressive so we spawn zerglings instead
-            await Program.GameConnection.SendRequest(RequestBuilder.DebugCreateUnit(Owner.Enemy, Units.Zergling, 12, pathFromNatural[SpawnDistance].ToVector3()));
+            await Program.GameConnection.SendRequest(RequestBuilder.DebugCreateUnit(Owner.Enemy, Units.Zergling, 12, mainPosition.ToVector3()));
             Controller.SetRealTime("Worker rush started");
 
             _isScenarioDone = true;

--- a/Bot/Unit.cs
+++ b/Bot/Unit.cs
@@ -380,10 +380,6 @@ public class Unit: ICanDie, IHavePosition {
         return true;
     }
 
-    public bool IsIdleOrMovingOrAttacking() {
-        return Orders.All(order => order.AbilityId is Abilities.Move or Abilities.Attack);
-    }
-
     /// <summary>
     /// Checks if an ability already targets a target position given a certain level of precision.
     /// </summary>
@@ -453,8 +449,20 @@ public class Unit: ICanDie, IHavePosition {
         return Orders.Count > 0;
     }
 
+    public bool IsIdle() {
+        return !Orders.Any();
+    }
+
+    public bool IsMoving() {
+        return Orders.Any(order => order.AbilityId == Abilities.Move);
+    }
+
+    public bool IsAttacking() {
+        return Orders.Any(order => order.AbilityId == Abilities.Attack);
+    }
+
     public bool IsMineralWalking() {
-        return Orders.Any(order => Abilities.Gather.Contains(order.AbilityId) || Abilities.ReturnCargo.Contains(order.AbilityId));
+        return Orders.Any(order => Abilities.Gather.Contains(order.AbilityId));
     }
 
     public override string ToString() {

--- a/Bot/Unit.cs
+++ b/Bot/Unit.cs
@@ -453,6 +453,10 @@ public class Unit: ICanDie, IHavePosition {
         return Orders.Count > 0;
     }
 
+    public bool IsMineralWalking() {
+        return Orders.Any(order => Abilities.Gather.Contains(order.AbilityId) || Abilities.ReturnCargo.Contains(order.AbilityId));
+    }
+
     public override string ToString() {
         if (Alliance == Alliance.Self) {
             return $"{Name}[{Tag}]";

--- a/Bot/Unit.cs
+++ b/Bot/Unit.cs
@@ -39,8 +39,8 @@ public class Unit: ICanDie, IHavePosition {
     public int InitialMineralCount = int.MaxValue;
     public int InitialVespeneCount = int.MaxValue;
 
-    public bool CanHitAir => UnitTypeData.Weapons.Any(weapon => weapon.Type is Weapon.Types.TargetType.Any or Weapon.Types.TargetType.Air);
-    public bool CanHitGround => UnitTypeData.Weapons.Any(weapon => weapon.Type is Weapon.Types.TargetType.Any or Weapon.Types.TargetType.Ground);
+    public bool CanHitAir => IsOperational && UnitTypeData.Weapons.Any(weapon => weapon.Type is Weapon.Types.TargetType.Any or Weapon.Types.TargetType.Air);
+    public bool CanHitGround => IsOperational && UnitTypeData.Weapons.Any(weapon => weapon.Type is Weapon.Types.TargetType.Any or Weapon.Types.TargetType.Ground);
     public bool IsFlying => RawUnitData.IsFlying;
     public bool IsBurrowed => RawUnitData.IsBurrowed;
     public bool IsCloaked => RawUnitData.Cloak == CloakState.Cloaked;

--- a/Bot/VideoClips/VideoClipPlayer.cs
+++ b/Bot/VideoClips/VideoClipPlayer.cs
@@ -7,7 +7,6 @@ using Bot.Debugging;
 using Bot.GameData;
 using Bot.GameSense;
 using Bot.Utils;
-using Bot.VideoClips.Clips;
 using Bot.VideoClips.Clips.RayCastingClips;
 using Bot.Wrapper;
 using SC2APIProtocol;


### PR DESCRIPTION
# Description
We currently have basically 0 micro for units.  
We've pushed a couple of updates to beat early game rushers and they worked great. However, we're at a point where they beat us because of their micro.  

In this update, we're introducing drone mineral walk kiting and laying a foundation to easily support more kinds of unit micro.

# What's new
- Renamed `ITactic` to `IUnitsControl`
- Changed the `IUnitsControl.Execute` to return the set of units that are not yet micro'ed. This allows you to chain `IUnitsControl`s.
- Added the `DroneKitingUnitsControl` to micro drones
- Tweaked `SneakAttack` to fit the new `IUnitsControl`
  - Fixed some issues, not sure if they were regressions or current bugs
  - It will need refactoring, but hopefully the previous performance is maintained
- Added a `UnitsController` that implements `IUnitsControl` and uses all the other `IUnitsControl` under the hood.
  - Updated the `AttackState` and `DefenseState` to use the `UnitsController`