### PR TITLE
Bugfix - Null `miningModule.AssignedResource` during `UpdateWorkerMiningAssignment`` 

### DIFF
--- a/Bot.Tests/UnitModules/MiningModule/MiningModuleTests.cs
+++ b/Bot.Tests/UnitModules/MiningModule/MiningModuleTests.cs
@@ -4,18 +4,39 @@ namespace Bot.Tests.UnitModules.MiningModule;
 
 public class MiningModuleTests: BaseTestClass {
     [Fact]
+    public void GivenNullWorker_WhenInstalling_DoesNotInstall() {
+        // Act
+        var miningModule = Bot.UnitModules.MiningModule.Install(null, null);
+
+        // Assert
+        Assert.Null(miningModule);
+    }
+
+    [Fact]
     public void GivenNullResource_WhenInstalling_DoesNotAssignResource() {
         // Arrange
         var worker = TestUtils.CreateUnit(Units.Drone);
 
         // Act
-        Bot.UnitModules.MiningModule.Install(worker, null);
-        var miningModule = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(worker);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, null);
 
         // Assert
         Assert.NotNull(miningModule);
         Assert.Null(miningModule.AssignedResource);
         Assert.Equal(Resources.ResourceType.None, miningModule.ResourceType);
+    }
+
+    [Fact]
+    public void GivenNullResource_WhenInstalling_DisablesModule() {
+        // Arrange
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, null);
+
+        // Act
+        var executed = miningModule.Execute();
+
+        // Assert
+        Assert.False(executed);
     }
 
     public static IEnumerable<object[]> MineralsTestData() {
@@ -29,17 +50,16 @@ public class MiningModuleTests: BaseTestClass {
         var worker = TestUtils.CreateUnit(Units.Drone);
 
         var resource = TestUtils.CreateUnit(mineralFieldType);
-        Bot.UnitModules.CapacityModule.Install(resource, 3);
+        var capacityModule = Bot.UnitModules.CapacityModule.Install(resource, 1);
 
         // Act
-        Bot.UnitModules.MiningModule.Install(worker, resource);
-        var module = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(worker);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, resource);
 
         // Assert
-        Assert.NotNull(module);
-        Assert.Equal(resource, module.AssignedResource);
-        Assert.Equal(Resources.ResourceType.Mineral, module.ResourceType);
-        Assert.Single(Bot.UnitModules.UnitModule.Get<Bot.UnitModules.CapacityModule>(resource).AssignedUnits);
+        Assert.NotNull(miningModule);
+        Assert.Equal(resource, miningModule.AssignedResource);
+        Assert.Equal(Resources.ResourceType.Mineral, miningModule.ResourceType);
+        Assert.Single(capacityModule.AssignedUnits);
     }
 
     public static IEnumerable<object[]> GasGeysersTestData() {
@@ -48,43 +68,27 @@ public class MiningModuleTests: BaseTestClass {
 
     [Theory]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenGasGeyser_WhenInstalling_AssignsGasGeyser(uint gasGeyserType) {
+    public void GivenGasGeyserWithCapacityModule_WhenInstalling_AssignsGasGeyserAndUpdatesCapacityModule(uint gasGeyserType) {
         // Arrange
         var worker = TestUtils.CreateUnit(Units.Drone);
 
         var resource = TestUtils.CreateUnit(gasGeyserType);
-        Bot.UnitModules.CapacityModule.Install(resource, 3);
+        var capacityModule = Bot.UnitModules.CapacityModule.Install(resource, 1);
 
         // Act
-        Bot.UnitModules.MiningModule.Install(worker, resource);
-        var module = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(worker);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, resource);
 
         // Assert
-        Assert.NotNull(module);
-        Assert.Equal(resource, module.AssignedResource);
-        Assert.Equal(Resources.ResourceType.Gas, module.ResourceType);
-        Assert.Single(Bot.UnitModules.UnitModule.Get<Bot.UnitModules.CapacityModule>(resource).AssignedUnits);
-    }
-
-    [Fact]
-    public void GivenNullResource_WhenInstalling_DisablesModule() {
-        // Arrange
-        var worker = TestUtils.CreateUnit(Units.Drone);
-        Bot.UnitModules.MiningModule.Install(worker, null);
-
-        var miningModule = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(worker);
-
-        // Act
-        var executed = miningModule.Execute();
-
-        // Assert
-        Assert.False(executed);
+        Assert.NotNull(miningModule);
+        Assert.Equal(resource, miningModule.AssignedResource);
+        Assert.Equal(Resources.ResourceType.Gas, miningModule.ResourceType);
+        Assert.Single(capacityModule.AssignedUnits);
     }
 
     [Theory]
     [MemberData(nameof(MineralsTestData))]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResource_WhenInstalling_EnablesModule(uint resourceType) {
+    public void GivenResourceWithCapacityModule_WhenInstalling_EnablesModule(uint resourceType) {
         // Arrange
         var resource = TestUtils.CreateUnit(resourceType);
         Bot.UnitModules.CapacityModule.Install(resource, 1);
@@ -104,7 +108,31 @@ public class MiningModuleTests: BaseTestClass {
     [Theory]
     [MemberData(nameof(MineralsTestData))]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResource_WhenAssigningResourceWithoutAllowingReleasingPreviousOne_DoesNothing(uint resourceType) {
+    public void GivenResourceWithoutCapacityModule_WhenInstalling_Throws(uint resourceType) {
+        // Arrange
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var resource = TestUtils.CreateUnit(resourceType);
+
+        // Act & Assert
+        Assert.Throws<NullReferenceException>(() => Bot.UnitModules.MiningModule.Install(worker, resource));
+    }
+
+    [Fact]
+    public void GivenNotAResourceResource_WhenInstalling_Throws() {
+        // Arrange
+        var notAResource = TestUtils.CreateUnit(Units.Zergling);
+        Bot.UnitModules.CapacityModule.Install(notAResource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => Bot.UnitModules.MiningModule.Install(worker, notAResource));
+    }
+
+    [Theory]
+    [MemberData(nameof(MineralsTestData))]
+    [MemberData(nameof(GasGeysersTestData))]
+    public void GivenResourceWithCapacityModule_WhenAssigningResourceWithoutAllowingReleasingPreviousOne_DoesNothing(uint resourceType) {
         // Arrange
         var initialResource = TestUtils.CreateUnit(resourceType);
         var initialCapacityModule = Bot.UnitModules.CapacityModule.Install(initialResource, 1);
@@ -127,7 +155,86 @@ public class MiningModuleTests: BaseTestClass {
     [Theory]
     [MemberData(nameof(MineralsTestData))]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResource_WhenReleasingResourceWithoutAllowingToUpdateTheCapacityModule_UnsetsAssignedResourceButDoesntUpdateCapacityModule(uint resourceType) {
+    public void GivenResourceWithCapacityModule_WhenAssigningResourceAndAllowingReleasingPreviousOne_ReleasesThePreviousResourceAndUpdatesCapacityModule(uint resourceType) {
+        // Arrange
+        var initialResource = TestUtils.CreateUnit(resourceType);
+        var initialCapacityModule = Bot.UnitModules.CapacityModule.Install(initialResource, 1);
+
+        var newResource = TestUtils.CreateUnit(resourceType);
+        var newCapacityModule = Bot.UnitModules.CapacityModule.Install(newResource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, initialResource);
+
+        // Act
+        miningModule.AssignResource(newResource, releasePreviouslyAssignedResource: true);
+
+        // Assert
+        Assert.Equal(newResource, miningModule.AssignedResource);
+        Assert.Empty(initialCapacityModule.AssignedUnits);
+        Assert.Single(newCapacityModule.AssignedUnits);
+    }
+
+    [Theory]
+    [MemberData(nameof(MineralsTestData))]
+    [MemberData(nameof(GasGeysersTestData))]
+    public void GivenResourceWithCapacityModule_WhenAssigningNullResourceAndAllowingReleasingPreviousOne_ReleasesThePreviousResourceAndUpdatesCapacityModule(uint resourceType) {
+        // Arrange
+        var initialResource = TestUtils.CreateUnit(resourceType);
+        var initialCapacityModule = Bot.UnitModules.CapacityModule.Install(initialResource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, initialResource);
+
+        // Act
+        miningModule.AssignResource(null, releasePreviouslyAssignedResource: true);
+
+        // Assert
+        Assert.Null(miningModule.AssignedResource);
+        Assert.Equal(Resources.ResourceType.None, miningModule.ResourceType);
+        Assert.Empty(initialCapacityModule.AssignedUnits);
+    }
+
+    [Theory]
+    [MemberData(nameof(MineralsTestData))]
+    [MemberData(nameof(GasGeysersTestData))]
+    public void GivenResourceWithCapacityModule_WhenAssigningNullResourceWithoutAllowingReleasingPreviousOne_DoesNothing(uint resourceType) {
+        // Arrange
+        var initialResource = TestUtils.CreateUnit(resourceType);
+        var initialCapacityModule = Bot.UnitModules.CapacityModule.Install(initialResource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, initialResource);
+
+        // Act
+        miningModule.AssignResource(null, releasePreviouslyAssignedResource: false);
+
+        // Assert
+        Assert.Equal(initialResource, miningModule.AssignedResource);
+        Assert.Equal(Resources.GetResourceType(initialResource), miningModule.ResourceType);
+        Assert.Single(initialCapacityModule.AssignedUnits);
+    }
+
+    [Fact]
+    public void GivenNullResource_WhenAssigningNotAResourceWithCapacityModule_Throws() {
+        // Arrange
+        var initialResource = TestUtils.CreateUnit(Units.MineralField);
+        Bot.UnitModules.CapacityModule.Install(initialResource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, initialResource);
+
+        var notAResource = TestUtils.CreateUnit(Units.Zergling);
+        Bot.UnitModules.CapacityModule.Install(notAResource, 1);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => miningModule.AssignResource(notAResource, releasePreviouslyAssignedResource: true));
+    }
+
+    [Theory]
+    [MemberData(nameof(MineralsTestData))]
+    [MemberData(nameof(GasGeysersTestData))]
+    public void GivenResourceWithCapacityModule_WhenReleasingResourceWithoutAllowingToUpdateCapacityModule_UnsetsAssignedResourceButDoesntUpdateCapacityModule(uint resourceType) {
         // Arrange
         var initialResource = TestUtils.CreateUnit(resourceType);
         var initialCapacityModule = Bot.UnitModules.CapacityModule.Install(initialResource, 1);
@@ -147,10 +254,30 @@ public class MiningModuleTests: BaseTestClass {
     [Theory]
     [MemberData(nameof(MineralsTestData))]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResource_WhenReleasingResource_DisablesModule(uint resourceType) {
+    public void GivenResourceWithCapacityModule_WhenReleasingResourceAndAllowingToUpdateCapacityModule_UnsetsAssignedResourceAndUpdatesCapacityModule(uint resourceType) {
+        // Arrange
+        var initialResource = TestUtils.CreateUnit(resourceType);
+        var initialCapacityModule = Bot.UnitModules.CapacityModule.Install(initialResource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        var miningModule = Bot.UnitModules.MiningModule.Install(worker, initialResource);
+
+        // Act
+        miningModule.ReleaseResource(updateCapacityModule: true);
+
+        // Assert
+        Assert.Null(miningModule.AssignedResource);
+        Assert.Equal(Resources.ResourceType.None, miningModule.ResourceType);
+        Assert.Empty(initialCapacityModule.AssignedUnits);
+    }
+
+    [Theory]
+    [MemberData(nameof(MineralsTestData))]
+    [MemberData(nameof(GasGeysersTestData))]
+    public void GivenResourceWithCapacityModule_WhenReleasingResource_DisablesModule(uint resourceType) {
         // Arrange
         var resource = TestUtils.CreateUnit(resourceType);
-        var capacityModule = Bot.UnitModules.CapacityModule.Install(resource, 1);
+        Bot.UnitModules.CapacityModule.Install(resource, 1);
 
         var worker = TestUtils.CreateUnit(Units.Drone);
         var miningModule = Bot.UnitModules.MiningModule.Install(worker, resource);
@@ -166,7 +293,7 @@ public class MiningModuleTests: BaseTestClass {
     [Theory]
     [MemberData(nameof(MineralsTestData))]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResource_WhenUninstalling_ReleasesWorkerFromResourceCapacityModule(uint resourceType) {
+    public void GivenResourceWithCapacityModule_WhenUninstalling_ReleasesWorkerFromResourceCapacityModule(uint resourceType) {
         // Arrange
         var resource = TestUtils.CreateUnit(resourceType);
         var capacityModule =  Bot.UnitModules.CapacityModule.Install(resource, 1);
@@ -181,6 +308,26 @@ public class MiningModuleTests: BaseTestClass {
         Assert.Empty(capacityModule.AssignedUnits);
     }
 
+    [Theory]
+    [MemberData(nameof(MineralsTestData))]
+    [MemberData(nameof(GasGeysersTestData))]
+    public void GivenResourceWithoutCapacityModule_WhenUninstalling_DoesNothing(uint resourceType) {
+        // Arrange
+        var resource = TestUtils.CreateUnit(resourceType);
+        Bot.UnitModules.CapacityModule.Install(resource, 1);
+
+        var worker = TestUtils.CreateUnit(Units.Drone);
+        Bot.UnitModules.MiningModule.Install(worker, resource);
+
+        Bot.UnitModules.UnitModule.Uninstall<Bot.UnitModules.CapacityModule>(resource);
+
+        // Act
+        var exception = Record.Exception(() => Bot.UnitModules.UnitModule.Uninstall<Bot.UnitModules.MiningModule>(worker));
+
+        // Assert
+        Assert.Null(exception);
+    }
+
     [Fact]
     public void GivenNullResource_WhenUninstalling_DoesNothing() {
         // Arrange
@@ -192,18 +339,6 @@ public class MiningModuleTests: BaseTestClass {
 
         // Assert
         Assert.Null(exception);
-    }
-
-    [Theory]
-    [MemberData(nameof(MineralsTestData))]
-    [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResourceWithoutCapacityModule_WhenInstalling_Throws(uint resourceType) {
-        // Arrange
-        var worker = TestUtils.CreateUnit(Units.Drone);
-        var resource = TestUtils.CreateUnit(resourceType);
-
-        // Act & Assert
-        Assert.Throws<NullReferenceException>(() => Bot.UnitModules.MiningModule.Install(worker, resource));
     }
 
     [Fact]

--- a/Bot.Tests/UnitModules/MiningModule/MiningModuleTests.cs
+++ b/Bot.Tests/UnitModules/MiningModule/MiningModuleTests.cs
@@ -110,7 +110,7 @@ public class MiningModuleTests: BaseTestClass {
         var module = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(unit);
 
         // Act
-        module.AssignResource(newResource);
+        module.AssignResource(newResource, releasePreviouslyAssignedResource: false);
 
         // Assert
         Assert.Equal(initialResource, module.AssignedResource);
@@ -130,7 +130,7 @@ public class MiningModuleTests: BaseTestClass {
         var module = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(unit);
 
         // Act
-        module.ReleaseResource();
+        module.ReleaseResource(updateCapacityModule: false);
 
         // Assert
         Assert.Null(module.AssignedResource);
@@ -151,7 +151,7 @@ public class MiningModuleTests: BaseTestClass {
         var module = Bot.UnitModules.UnitModule.Get<Bot.UnitModules.MiningModule>(unit);
 
         // Act
-        module.ReleaseResource();
+        module.ReleaseResource(updateCapacityModule: false);
         var executed = module.Execute();
 
         // Assert

--- a/Bot.Tests/UnitModules/MiningModule/MiningModuleTests.cs
+++ b/Bot.Tests/UnitModules/MiningModule/MiningModuleTests.cs
@@ -24,10 +24,11 @@ public class MiningModuleTests: BaseTestClass {
 
     [Theory]
     [MemberData(nameof(MineralsTestData))]
-    public void GivenMineralField_WhenInstalling_AssignsMineralField(uint mineralFieldType) {
+    public void GivenMineralFieldWithCapacityModule_WhenInstalling_AssignsMineralFieldAndUpdatesCapacityModule(uint mineralFieldType) {
         // Arrange
         var unit = TestUtils.CreateUnit(Units.Drone);
         var resource = TestUtils.CreateUnit(mineralFieldType);
+        Bot.UnitModules.CapacityModule.Install(resource, 3);
 
         // Act
         Bot.UnitModules.MiningModule.Install(unit, resource);
@@ -37,6 +38,7 @@ public class MiningModuleTests: BaseTestClass {
         Assert.NotNull(module);
         Assert.Equal(resource, module.AssignedResource);
         Assert.Equal(Resources.ResourceType.Mineral, module.ResourceType);
+        Assert.Single(Bot.UnitModules.UnitModule.Get<Bot.UnitModules.CapacityModule>(resource).AssignedUnits);
     }
 
     public static IEnumerable<object[]> GasGeysersTestData() {
@@ -49,6 +51,7 @@ public class MiningModuleTests: BaseTestClass {
         // Arrange
         var unit = TestUtils.CreateUnit(Units.Drone);
         var resource = TestUtils.CreateUnit(gasGeyserType);
+        Bot.UnitModules.CapacityModule.Install(resource, 3);
 
         // Act
         Bot.UnitModules.MiningModule.Install(unit, resource);
@@ -58,6 +61,7 @@ public class MiningModuleTests: BaseTestClass {
         Assert.NotNull(module);
         Assert.Equal(resource, module.AssignedResource);
         Assert.Equal(Resources.ResourceType.Gas, module.ResourceType);
+        Assert.Single(Bot.UnitModules.UnitModule.Get<Bot.UnitModules.CapacityModule>(resource).AssignedUnits);
     }
 
     [Fact]
@@ -194,17 +198,12 @@ public class MiningModuleTests: BaseTestClass {
     [Theory]
     [MemberData(nameof(MineralsTestData))]
     [MemberData(nameof(GasGeysersTestData))]
-    public void GivenResourceWithoutCapacityModule_WhenUninstalling_DoesNothing(uint resourceType) {
+    public void GivenResourceWithoutCapacityModule_WhenInstalling_Throws(uint resourceType) {
         // Arrange
         var resource = TestUtils.CreateUnit(resourceType);
-
         var unit = TestUtils.CreateUnit(Units.Drone);
-        Bot.UnitModules.MiningModule.Install(unit, resource);
 
-        // Act
-        var exception = Record.Exception(() => Bot.UnitModules.UnitModule.Uninstall<Bot.UnitModules.MiningModule>(unit));
-
-        // Assert
-        Assert.Null(exception);
+        // Act & Assert
+        Assert.Throws<NullReferenceException>(() => Bot.UnitModules.MiningModule.Install(unit, resource));
     }
 }

--- a/Bot/Logger.cs
+++ b/Bot/Logger.cs
@@ -87,7 +87,16 @@ public static class Logger {
 
     public static void Error(string error, params object[] parameters) {
         Console.ForegroundColor = ConsoleColor.Red;
-        WriteLine("ERROR", $"({GetNameOfCallingClass()}) {error}", parameters);
+
+        var stackTrace = string.Join(
+            Environment.NewLine,
+            Environment.StackTrace
+                .Split(Environment.NewLine)
+                .Skip(2) // Skipping the Environment.StackTrace and Logger.Error calls
+                .Take(7)
+        );
+
+        WriteLine("ERROR", $"({GetNameOfCallingClass()}) {error}\n{stackTrace}", parameters);
         Console.ResetColor();
     }
 

--- a/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisorReleaser.cs
+++ b/Bot/Managers/EconomyManagement/TownHallSupervision/TownHallSupervisorReleaser.cs
@@ -84,7 +84,9 @@ public partial class TownHallSupervisor {
             UnitModule.Uninstall<DebugLocationModule>(mineral);
             var capacityModule = UnitModule.Uninstall<CapacityModule>(mineral);
 
-            capacityModule.AssignedUnits.ForEach(worker => UnitModule.Get<MiningModule>(worker).ReleaseResource());
+            capacityModule.AssignedUnits.ForEach(worker => {
+                UnitModule.Get<MiningModule>(worker).ReleaseResource(updateCapacityModule: false);
+            });
         }
 
         private void ReleaseGas(Unit gas) {
@@ -110,7 +112,20 @@ public partial class TownHallSupervisor {
 
             // TODO GD Something can be null here, that's odd
             // TODO GD Understand why and fix it
-            capacityModule?.AssignedUnits.ForEach(worker => UnitModule.Get<MiningModule>(worker)?.ReleaseResource());
+            if (capacityModule == null) {
+                Logger.Error($"Null capacity module for extractor at position: {extractor.Position}");
+                return;
+            }
+
+            capacityModule.AssignedUnits.ForEach(worker => {
+                var miningModule = UnitModule.Get<MiningModule>(worker);
+                if (miningModule == null) {
+                    Logger.Error($"Null mining module for worker assigned to extractor at position: {extractor.Position}");
+                    return;
+                }
+
+                miningModule.ReleaseResource(updateCapacityModule: false);
+            });
         }
     }
 }

--- a/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorAssigner.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorAssigner.cs
@@ -1,5 +1,4 @@
-﻿using Bot.GameData;
-using Bot.UnitModules;
+﻿using Bot.UnitModules;
 
 namespace Bot.Managers.WarManagement.ArmySupervision;
 

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttackUnitsControl/SetupState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/SneakAttackUnitsControl/SetupState.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Bot.ExtensionMethods;
 using Bot.GameData;
 using Bot.GameSense;
-using Bot.UnitModules;
 
 namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
 

--- a/Bot/UnitModules/CapacityModule.cs
+++ b/Bot/UnitModules/CapacityModule.cs
@@ -10,7 +10,19 @@ public class CapacityModule: UnitModule, IWatchUnitsDie {
     private readonly Unit _unit;
     private readonly bool _showDebugInfo;
 
-    public int MaxCapacity;
+    private int _maxCapacity;
+    public int MaxCapacity {
+        get => _maxCapacity;
+        set {
+            if (value < 0) {
+                Logger.Error($"Trying to set a negative MaxCapacity: {value}");
+                _maxCapacity = 0;
+            }
+
+            _maxCapacity = value;
+        }
+    }
+
     public readonly List<Unit> AssignedUnits = new List<Unit>();
 
     public int AvailableCapacity => MaxCapacity - AssignedUnits.Count;

--- a/Bot/UnitModules/CapacityModule.cs
+++ b/Bot/UnitModules/CapacityModule.cs
@@ -27,10 +27,15 @@ public class CapacityModule: UnitModule, IWatchUnitsDie {
 
     public int AvailableCapacity => MaxCapacity - AssignedUnits.Count;
 
-    public static void Install(Unit unit, int maxCapacity, bool showDebugInfo = true) {
-        if (PreInstallCheck(Tag, unit)) {
-            unit.Modules.Add(Tag, new CapacityModule(unit, maxCapacity, showDebugInfo));
+    public static CapacityModule Install(Unit unit, int maxCapacity, bool showDebugInfo = true) {
+        if (!PreInstallCheck(Tag, unit)) {
+            return null;
         }
+
+        var capacityModule = new CapacityModule(unit, maxCapacity, showDebugInfo);
+        unit.Modules.Add(Tag, capacityModule);
+
+        return capacityModule;
     }
 
     private CapacityModule(Unit unit, int maxCapacity, bool showDebugInfo) {

--- a/Bot/UnitModules/MiningModule/MiningModule.cs
+++ b/Bot/UnitModules/MiningModule/MiningModule.cs
@@ -9,10 +9,15 @@ public class MiningModule: UnitModule {
     public Resources.ResourceType ResourceType;
     public Unit AssignedResource;
 
-    public static void Install(Unit worker, Unit assignedResource) {
-        if (PreInstallCheck(Tag, worker)) {
-            worker.Modules.Add(Tag, new MiningModule(worker, assignedResource));
+    public static MiningModule Install(Unit worker, Unit assignedResource) {
+        if (!PreInstallCheck(Tag, worker)) {
+            return null;
         }
+
+        var miningModule = new MiningModule(worker, assignedResource);
+        worker.Modules.Add(Tag, miningModule);
+
+        return miningModule;
     }
 
     private MiningModule(Unit worker, Unit assignedResource) {

--- a/Bot/UnitModules/MiningModule/MiningModule.cs
+++ b/Bot/UnitModules/MiningModule/MiningModule.cs
@@ -1,4 +1,6 @@
-﻿namespace Bot.UnitModules;
+﻿using System;
+
+namespace Bot.UnitModules;
 
 public class MiningModule: UnitModule {
     public const string Tag = "MiningModule";
@@ -65,7 +67,7 @@ public class MiningModule: UnitModule {
         {
             Resources.ResourceType.Gas => new GasMiningStrategy(_worker, newlyAssignedResource),
             Resources.ResourceType.Mineral => new MineralMiningStrategy(_worker, newlyAssignedResource),
-            _ => null
+            _ => throw new ArgumentException("Cannot create strategy because the assigned resource doesn't have a resource type."),
         };
 
         Enable();
@@ -97,7 +99,7 @@ public class MiningModule: UnitModule {
             resourceCapacityModule.Release(_worker);
         }
         else {
-            Logger.Error("({0}) Assigned resource {1} had no capacity module during uninstallation", this, AssignedResource);
+            Logger.Error($"Assigned resource {AssignedResource} had no capacity module during uninstallation");
         }
     }
 

--- a/Bot/UnitModules/UnitModule.cs
+++ b/Bot/UnitModules/UnitModule.cs
@@ -42,13 +42,13 @@ public abstract class UnitModule: IUnitModule {
 
     public static bool PreInstallCheck(string moduleTag, Unit unit) {
         if (unit == null) {
-            Logger.Error("Pre-install: Unit was null when trying to install {0}.", moduleTag);
+            Logger.Error($"Pre-install: Unit was null when trying to install {moduleTag}.");
 
             return false;
         }
 
         if (unit.Modules.Remove(moduleTag)) {
-            Logger.Error("Pre-install: Removed {0} from {1}.", moduleTag, unit);
+            Logger.Error($"Pre-install: Removed {moduleTag} from {unit}.");
         }
 
         return true;

--- a/Bot/UnitModules/UnitModule.cs
+++ b/Bot/UnitModules/UnitModule.cs
@@ -66,6 +66,7 @@ public abstract class UnitModule: IUnitModule {
 
     public static T Get<T>(Unit unit) where T: UnitModule {
         if (unit == null) {
+            Logger.Error($"Trying to get the {typeof(T)} module of a unit, but the unit is null");
             return null;
         }
 


### PR DESCRIPTION
# Description
We hit the following error:
```
[12:52:17 | 14:15 @ 19174]   DEBUG: (TownHallSupervisor[4336910337]) Assigned Drone[4414242829]
[12:52:17 | 14:15 @ 19174]   DEBUG: (EconomyManager) Dispatched Drone[4414242829]
[12:52:17 | 14:15 @ 19174]   ERROR: (CapacityModule) Trying to release one unit from CapacityModule, but there's no assigned units
[12:52:17 | 14:15 @ 19174]   ERROR: (Program) System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Bot.Managers.EconomyManagement.TownHallSupervision.TownHallSupervisor.UpdateWorkerMiningAssignment(Unit worker, Unit assignedResource) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Managers\EconomyManagement\TownHallSupervision\TownHallSupervisor.cs:line 250
   at Bot.Managers.EconomyManagement.TownHallSupervision.TownHallSupervisor.UpdateGasAssignments() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Managers\EconomyManagement\TownHallSupervision\TownHallSupervisor.cs:line 180
   at Bot.Managers.EconomyManagement.TownHallSupervision.TownHallSupervisor.Supervise() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Managers\EconomyManagement\TownHallSupervision\TownHallSupervisor.cs:line 82
   at Bot.Managers.Supervisor.OnFrame() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Managers\Supervisor.cs:line 15
   at Bot.Managers.EconomyManagement.EconomyManager.ManagementPhase() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Managers\EconomyManagement\EconomyManager.cs:line 83
   at Bot.Managers.Manager.OnFrame() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Managers\Manager.cs:line 19
   at Bot.SajuukBot.<>c.<DoOnFrame>b__7_0(Manager manager) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\SajuukBot.cs:line 36
   at System.Collections.Generic.List`1.ForEach(Action`1 action)
   at Bot.SajuukBot.DoOnFrame() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\SajuukBot.cs:line 36
   at Bot.PoliteBot.OnFrame() in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\PoliteBot.cs:line 34
   at Bot.Wrapper.GameConnection.RunBot(IBot bot, ResponseObservation observation) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Wrapper\GameConnection.cs:line 248
   at Bot.Wrapper.GameConnection.Run(IBot bot, UInt32 playerId, Boolean runDataAnalyzersOnly) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Wrapper\GameConnection.cs:line 223
   at Bot.Wrapper.GameConnection.RunLadder(IBot bot, Int32 gamePort, Int32 startPort) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Wrapper\GameConnection.cs:line 162
   at Bot.Wrapper.GameConnection.RunLadder(IBot bot, String[] args) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Wrapper\GameConnection.cs:line 155
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Bot.Program.PlayLadderGame(String[] args) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Program.cs:line 104
   at Bot.Program.Main(String[] args) in C:\Users\Guillaume\Dev\sajuuk-sc2\Bot\Program.cs:line 49
[12:52:17 | 14:15 @ 19174]    INFO: Terminated.
```

After investigating, I found that during `UpdateWorkerMiningAssignment`, the mining module was null because the worker was null. The only explanation as to why the worker would be null there is if in `UpdateGasAssignments` we hit a case where `extractorCapacityModule.AvailableCapacity` was negative, which can only happen if `extractorCapacityModule.MaxCapacity` is negative. This is not intended, but I couldn't see how we got there.

# What's new
- Added a setter to `CapacityModule.MaxCapacity` to ensure that it is always positive.
  - We log an error when it is negative, and set it to 0 instead
- Added a setter to `TownHallSupervisor.GasWorkersCap` to ensure that it is always positive.
  - We log an error when it is negative, and set it to 0 instead
- Added a stack trace to all error logs
- Moved logic inside the `MiningModule` regarding the assigned resource `CapacityModule` management.
  - When assigning a new resource, it will now update the assigned resource capacity module
  - When releasing a resource, it will now update the released resource capacity module
  - When assigning a new resource, it will now release the currently assigned resource
- Added error logging to unexpected edge cases
- Updated `MiningModule` tests

