### PR TITLE
Bugfix - Fixed stutter step performance issues

### DIFF
--- a/Bot/Debugging/ExecutionTimeDebugger.cs
+++ b/Bot/Debugging/ExecutionTimeDebugger.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Bot.ExtensionMethods;
+
+namespace Bot.Debugging;
+
+public class ExecutionTimeDebugger {
+    private readonly Dictionary<string, Stopwatch> _timers = new Dictionary<string, Stopwatch>();
+
+    public void StartTimer(string tag) {
+        if (_timers.ContainsKey(tag)) {
+            return;
+        }
+
+        _timers[tag] = new Stopwatch();
+        _timers[tag].Start();
+    }
+
+    public void StopTimer(string tag) {
+        if (!_timers.ContainsKey(tag)) {
+            return;
+        }
+
+        _timers[tag].Stop();
+    }
+
+    public double GetExecutionTime(string tag) {
+        if (!_timers.ContainsKey(tag)) {
+            return 0;
+        }
+
+        return _timers[tag].GetElapsedTimeMs();
+    }
+
+    public void LogExecutionTimes(string title) {
+        var performances = _timers.Select(kv => $"{kv.Key} {kv.Value.GetElapsedTimeMs():F2}ms");
+
+        Logger.Performance($"{title} " + string.Join(" | ", performances));
+    }
+
+    public void Reset() {
+        foreach (var (_, timer) in _timers) {
+            timer.Stop();
+        }
+
+        _timers.Clear();
+    }
+}

--- a/Bot/ExtensionMethods/StopwatchExtensions.cs
+++ b/Bot/ExtensionMethods/StopwatchExtensions.cs
@@ -10,9 +10,4 @@ public static class StopwatchExtensions {
 
         return Math.Round(1e3 * timeInSeconds, decimals);
     }
-
-    public static void LogPerformance(this Stopwatch stopwatch, string name) {
-        stopwatch.Stop();
-        PerformanceLogger.Log($"{name,-25} {stopwatch.GetElapsedTimeMs(),6:F2} ms");
-    }
 }

--- a/Bot/GameSense/RegionTracking/RegionTracker.cs
+++ b/Bot/GameSense/RegionTracking/RegionTracker.cs
@@ -102,7 +102,7 @@ public class RegionTracker : INeedUpdating {
 
     /// <summary>
     /// Gets the defense score of the region.
-    /// The defense score represents valuable defending this region is
+    /// The defense score represents how valuable defending this region is
     /// </summary>
     /// <param name="region">The region to get the defense score of</param>
     /// <returns>The defense score of the given region</returns>

--- a/Bot/Managers/WarManagement/States/MidGame/MidGameDispatcher.cs
+++ b/Bot/Managers/WarManagement/States/MidGame/MidGameDispatcher.cs
@@ -4,7 +4,7 @@ public class MidGameDispatcher : Dispatcher<MidGameBehaviour> {
     public MidGameDispatcher(MidGameBehaviour client) : base(client) {}
 
     public override void Dispatch(Unit unit) {
-        Logger.Debug("({0}) Dispatched {1}", Client, unit);
+        Logger.Debug($"({Client}) Dispatched {unit}");
 
         if (Client.Stance == Stance.Attack) {
             Client.AttackSupervisor.Assign(unit);

--- a/Bot/Program.cs
+++ b/Bot/Program.cs
@@ -26,7 +26,7 @@ public class Program {
     private const Race OpponentRace = Race.Terran;
     private const Difficulty OpponentDifficulty = Difficulty.VeryHard;
 
-    private const bool RealTime = true;
+    private const bool RealTime = false;
 
     public static GameConnection GameConnection { get; private set; }
     public static bool DebugEnabled { get; private set; }


### PR DESCRIPTION
# Description
I noticed massive slowdowns since introducing stutter step.  
I pinpointed that breaking cycles would take up to a few seconds sometimes, while the rest of the algorithm took less than a millisecond.

# What's new
- Optimized the graph traversal when breaking cycles
- Added an `ExecutionTimeDebugger` to facilitate measuring and logging performance.
- Added performance logging inside stutter step to be able to diagnose performance issues in the future.