### PR TITLE
Feature - Improve stutter step

### DIFF
--- a/Bot.Tests/Managers/WarManagement/ArmySupervision/UnitsControl/StutterStepUnitsControl/PressureGraphTests.cs
+++ b/Bot.Tests/Managers/WarManagement/ArmySupervision/UnitsControl/StutterStepUnitsControl/PressureGraphTests.cs
@@ -1,0 +1,278 @@
+﻿using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.StutterStepUnitsControl;
+
+namespace Bot.Tests.Managers.WarManagement.ArmySupervision.UnitsControl.StutterStepUnitsControl;
+
+public class PressureGraphTests {
+    [Fact]
+    public void Given_ABA_Cycle_WhenBreakCycles_ThenCycleIsBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A"] = new()
+            {
+                From = { "B" },
+                To = { "B" }
+            },
+            ["B"] = new()
+            {
+                From = { "A" },
+                To = { "A" }
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Single(removedPressures);
+
+        var removedPressure = removedPressures[0];
+        Assert.Equal("A", removedPressure.From.First());
+        Assert.Equal("B", removedPressure.To.First());
+    }
+    [Fact]
+    public void GivenTwo_ABA_Cycles_WhenBreakCycles_ThenCyclesAreBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A"] = new()
+            {
+                From = { "B" },
+                To = { "B" }
+            },
+            ["B"] = new()
+            {
+                From = { "A" },
+                To = { "A" }
+            },
+            ["C"] = new()
+            {
+                From = { "D" },
+                To = { "D" }
+            },
+            ["D"] = new()
+            {
+                From = { "C" },
+                To = { "C" }
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Equal(2, removedPressures.Count);
+
+        Assert.Equal("A", removedPressures[0].From.First());
+        Assert.Equal("B", removedPressures[0].To.First());
+
+        Assert.Equal("C", removedPressures[1].From.First());
+        Assert.Equal("D", removedPressures[1].To.First());
+    }
+
+    [Fact]
+    public void Given_ABCA_Cycle_WhenBreakCycles_ThenCycleIsBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A"] = new()
+            {
+                From = { "C" },
+                To = { "B" }
+            },
+            ["B"] = new()
+            {
+                From = { "A" },
+                To = { "C" }
+            },
+            ["C"] = new()
+            {
+                From = { "B" },
+                To = { "A" }
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Single(removedPressures);
+
+        var removedPressure = removedPressures[0];
+        Assert.Equal("A", removedPressure.From.First());
+        Assert.Equal("B", removedPressure.To.First());
+    }
+
+    [Fact]
+    public void GivenCycleWithStartButNoEnd_WhenBreakCycles_ThenCycleIsBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A"] = new()
+            {
+                To = { "B" }
+            },
+            ["B"] = new()
+            {
+                From = { "A", "D" },
+                To = { "C" }
+            },
+            ["C"] = new()
+            {
+                From = { "B" },
+                To = { "D" }
+            },
+            ["D"] = new()
+            {
+                From = { "C" },
+                To = { "B" }
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Single(removedPressures);
+
+        var removedPressure = removedPressures[0];
+        Assert.Equal("D", removedPressure.From.First());
+        Assert.Equal("B", removedPressure.To.First());
+    }
+
+    [Fact]
+    public void GivenCycleWithEndButNoStart_WhenBreakCycles_ThenCycleIsBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A"] = new()
+            {
+                From = { "C" },
+                To = { "B" }
+            },
+            ["B"] = new()
+            {
+                From = { "A" },
+                To = { "C" }
+            },
+            ["C"] = new()
+            {
+                From = { "B" },
+                To = { "D", "A" }
+            },
+            ["D"] = new()
+            {
+                From = { "C" },
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Single(removedPressures);
+
+        var removedPressure = removedPressures[0];
+        Assert.Equal("C", removedPressure.From.First());
+        Assert.Equal("A", removedPressure.To.First());
+    }
+
+    [Fact]
+    public void GivenCycleWithStartAndEndNodes_WhenBreakCycles_ThenCycleIsBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A"] = new()
+            {
+                To = { "B" }
+            },
+            ["B"] = new()
+            {
+                From = { "A", "D" },
+                To = { "C" }
+            },
+            ["C"] = new()
+            {
+                From = { "B" },
+                To = { "D" }
+            },
+            ["D"] = new()
+            {
+                From = { "C" },
+                To = { "B", "E" }
+            },
+            ["E"] = new()
+            {
+                From = { "D" },
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Single(removedPressures);
+
+        var removedPressure = removedPressures[0];
+        Assert.Equal("D", removedPressure.From.First());
+        Assert.Equal("B", removedPressure.To.First());
+    }
+
+    [Fact]
+    public void GivenGraphWithoutCycles_WhenBreakCycles_ThenNoCyclesAreBroken() {
+        // Arrange
+        var pressureGraph = new Dictionary<string, PressureGraph.Pressure<string>>
+        {
+            ["A1"] = new()
+            {
+                To = { "B1", "C1" }
+            },
+            ["B1"] = new()
+            {
+                From = { "A1" },
+                To = { "D1", "E1" }
+            },
+            ["C1"] = new()
+            {
+                From = { "A1" },
+                To = { "E1" }
+            },
+            ["D1"] = new()
+            {
+                From = { "B1" },
+            },
+            ["E1"] = new()
+            {
+                From = { "B1", "C1" },
+            },
+            ["A2"] = new()
+            {
+                From = { "B2", "C2" }
+            },
+            ["B2"] = new()
+            {
+                To = { "A2" },
+                From = { "D2", "E2" }
+            },
+            ["C2"] = new()
+            {
+                To = { "A2" },
+                From = { "E2" }
+            },
+            ["D2"] = new()
+            {
+                To = { "B2" },
+            },
+            ["E2"] = new()
+            {
+                To = { "B2", "C2" },
+            },
+        };
+
+        // Act
+        var removedPressures = PressureGraph.BreakCycles(pressureGraph);
+
+        // Assert
+        Assert.Empty(removedPressures);
+    }
+}

--- a/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorAssigner.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorAssigner.cs
@@ -1,6 +1,4 @@
-﻿using Bot.UnitModules;
-
-namespace Bot.Managers.WarManagement.ArmySupervision;
+﻿namespace Bot.Managers.WarManagement.ArmySupervision;
 
 public partial class ArmySupervisor {
     private class ArmySupervisorAssigner: IAssigner {
@@ -12,9 +10,6 @@ public partial class ArmySupervisor {
 
         public void Assign(Unit unit) {
             _supervisor.Army.Add(unit);
-
-            AttackPriorityModule.Install(unit);
-
             Logger.Debug("({0}) Assigned {1}", _supervisor, unit);
         }
     }

--- a/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorReleaser.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorReleaser.cs
@@ -12,9 +12,6 @@ public partial class ArmySupervisor {
 
         public void Release(Unit unit) {
             _supervisor.Army.Remove(unit);
-
-            UnitModule.Uninstall<AttackPriorityModule>(unit);
-
             Logger.Debug("({0}) Released {1}", _supervisor, unit);
         }
     }

--- a/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/ApproachState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/ApproachState.cs
@@ -40,6 +40,10 @@ public class ApproachState : RegionalArmySupervisionState {
         return SupervisedUnits;
     }
 
+    public override void Release(Unit unit) {
+        // Nothing to do
+    }
+
     /// <summary>
     /// Gets all the units that are in position and ready to attack the target region.
     /// </summary>

--- a/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/DisengageState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/DisengageState.cs
@@ -11,7 +11,7 @@ public class DisengageState : RegionalArmySupervisionState {
     private const float SafetyDistance = 5;
     private const float SafetyDistanceTolerance = SafetyDistance / 2;
 
-    private IReadOnlyCollection<Unit> _unitsInSafePosition = new List<Unit>();
+    private HashSet<Unit> _unitsInSafePosition = new HashSet<Unit>();
 
     /// <summary>
     /// Evacuate units from the target region and keep rallying other units to a safe position.
@@ -46,20 +46,24 @@ public class DisengageState : RegionalArmySupervisionState {
         return _unitsInSafePosition;
     }
 
+    public override void Release(Unit unit) {
+        _unitsInSafePosition.Remove(unit);
+    }
+
     /// <summary>
     /// Gets all the units that are in a safe position
     /// </summary>
     /// <param name="supervisedUnits">The units to consider</param>
     /// <param name="enemyArmy">The enemy army to strike</param>
     /// <returns>The units that are in a safe position</returns>
-    private static IReadOnlyCollection<Unit> GetUnitsInSafePosition(IReadOnlyCollection<Unit> supervisedUnits, IReadOnlyCollection<Unit> enemyArmy) {
+    private static HashSet<Unit> GetUnitsInSafePosition(HashSet<Unit> supervisedUnits, IReadOnlyCollection<Unit> enemyArmy) {
         if (!enemyArmy.Any()) {
             return supervisedUnits;
         }
 
         return supervisedUnits
             .Where(unit => RegionTracker.GetForce(unit.GetRegion(), Alliance.Enemy) <= 0)
-            .ToList();
+            .ToHashSet();
     }
 
     /// <summary>

--- a/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/EngageState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/EngageState.cs
@@ -7,7 +7,7 @@ using Bot.MapKnowledge;
 namespace Bot.Managers.WarManagement.ArmySupervision.RegionalArmySupervision;
 
 public class EngageState : RegionalArmySupervisionState {
-    private IReadOnlySet<Unit> _unitsReadyToAttack = new HashSet<Unit>();
+    private HashSet<Unit> _unitsReadyToAttack = new HashSet<Unit>();
 
     /// <summary>
     /// Attack the target region with units that are ready to fight.
@@ -43,6 +43,10 @@ public class EngageState : RegionalArmySupervisionState {
         return EnemyArmy.GetForce() == 0
             ? SupervisedUnits
             : SupervisedUnits.Except(_unitsReadyToAttack);
+    }
+
+    public override void Release(Unit unit) {
+        _unitsReadyToAttack.Remove(unit);
     }
 
     /// <summary>

--- a/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/RegionalArmySupervisionState.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/RegionalArmySupervisionState.cs
@@ -11,7 +11,7 @@ namespace Bot.Managers.WarManagement.ArmySupervision.RegionalArmySupervision;
 
 public abstract class RegionalArmySupervisionState : State<RegionalArmySupervisor> {
     public IReadOnlyCollection<Unit> EnemyArmy { protected get; set; } = new List<Unit>();
-    public IReadOnlyCollection<Unit> SupervisedUnits { protected get; set; } = new List<Unit>();
+    public HashSet<Unit> SupervisedUnits { protected get; set; } = new HashSet<Unit>();
     public IRegion TargetRegion { protected get; set; }
     public IUnitsControl UnitsController { protected get; set; }
 
@@ -20,6 +20,12 @@ public abstract class RegionalArmySupervisionState : State<RegionalArmySuperviso
     /// </summary>
     /// <returns>The units that can be released.</returns>
     public abstract IEnumerable<Unit> GetReleasableUnits();
+
+    /// <summary>
+    /// Releases a unit.
+    /// You should remove the unit from any internal state that you own.
+    /// </summary>
+    public abstract void Release(Unit unit);
 
     /// <summary>
     /// For each region, compute the regions that should be avoided.

--- a/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/RegionalArmySupervisor.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/RegionalArmySupervisor.cs
@@ -23,6 +23,7 @@ public class RegionalArmySupervisor : Supervisor {
 
     public RegionalArmySupervisor(IRegion targetRegion) {
         _targetRegion = targetRegion;
+        Releaser = new RegionalArmySupervisorReleaser(this);
         _stateMachine = new StateMachine<RegionalArmySupervisor, RegionalArmySupervisionState>(this, new ApproachState());
     }
 
@@ -89,10 +90,19 @@ public class RegionalArmySupervisor : Supervisor {
         return _stateMachine.State.GetReleasableUnits();
     }
 
+    public override string ToString() {
+        return $"RegionalArmySupervisor[{_targetRegion.Id}]";
+    }
+
     // TODO GD Rework assigner/releaser. It's not helpful at all
     protected override IAssigner Assigner { get; } = new DummyAssigner();
-    protected override IReleaser Releaser { get; } = new DummyReleaser();
+    protected override IReleaser Releaser { get; }
 
     private class DummyAssigner : IAssigner { public void Assign(Unit unit) {} }
-    private class DummyReleaser : IReleaser { public void Release(Unit unit) {} }
+    private class RegionalArmySupervisorReleaser : Releaser<RegionalArmySupervisor> {
+        public RegionalArmySupervisorReleaser(RegionalArmySupervisor client) : base(client) {}
+        public override void Release(Unit unit) {
+            Client._stateMachine.State.Release(unit);
+        }
+    }
 }

--- a/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/RegionalArmySupervisor.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/RegionalArmySupervisor.cs
@@ -13,6 +13,8 @@ using Bot.StateManagement;
 namespace Bot.Managers.WarManagement.ArmySupervision.RegionalArmySupervision;
 
 public class RegionalArmySupervisor : Supervisor {
+    private const bool Debug = false;
+
     private readonly IUnitsControl _unitsController = new UnitsController();
     private readonly IRegion _targetRegion;
     private readonly StateMachine<RegionalArmySupervisor, RegionalArmySupervisionState> _stateMachine;
@@ -60,6 +62,10 @@ public class RegionalArmySupervisor : Supervisor {
     }
 
     private void DebugUnits() {
+        if (!Debug) {
+            return;
+        }
+
         var stateSymbol = _stateMachine.State switch
         {
             ApproachState => "MOVE",

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/StutterStepUnitsControl/PressureGraph.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/StutterStepUnitsControl/PressureGraph.cs
@@ -1,0 +1,199 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl.StutterStepUnitsControl;
+
+public static class PressureGraph {
+    public struct Pressure<TItem> {
+        public readonly HashSet<TItem> From = new HashSet<TItem>();
+        public readonly HashSet<TItem> To = new HashSet<TItem>();
+
+        public Pressure() {}
+    }
+
+    /// <summary>
+    /// Break cycles in the given pressure graph.
+    /// We will do a depth first traversal of the graph starting from the "root" nodes, that is the units in the front that do not pressure anyone.
+    /// While traversing, we keep track of the current branch and if we visit a member of the branch twice before reaching the end, we cut the last edge.
+    ///
+    /// The pressure graph will be mutated.
+    ///
+    /// </summary>
+    /// <param name="pressureGraph">The pressure graph to break the cycles of</param>
+    /// <returns>The list of all removed pressures.</returns>
+    // TODO GD This is probably the dirtiest code of the project. Admittedly, I am tired. However, I'm not lazy, and the code is tested!
+    // TODO GD This is a case of "if it ain't broke, don't fix it"!
+    public static List<Pressure<TItem>> BreakCycles<TItem>(IReadOnlyDictionary<TItem, Pressure<TItem>> pressureGraph) {
+        var removedPressures = new List<Pressure<TItem>>();
+
+        var fullyCleared = new HashSet<TItem>();
+
+        // Start from the start
+        foreach (var (item, _) in pressureGraph.Where(kv => !kv.Value.From.Any())) {
+            var currentBranchSet = new HashSet<TItem>();
+            var currentBranchStack = new Stack<TItem>();
+
+            var explorationStack = new Stack<TItem>();
+            explorationStack.Push(item);
+
+            // Depth first search
+            // When backtracking (reaching the end of a branch, no pressure from), clear the currentBranchSet because there were no cycles
+            var backtracking = false;
+            while (explorationStack.Any()) {
+                var toExplore = explorationStack.Pop();
+
+                if (backtracking) {
+                    while (!pressureGraph[currentBranchStack.Peek()].To.Contains(toExplore)) {
+                        fullyCleared.Add(currentBranchStack.Pop());
+                    }
+
+                    currentBranchSet = currentBranchStack.ToHashSet();
+                    backtracking = false;
+                }
+
+                currentBranchSet.Add(toExplore);
+                currentBranchStack.Push(toExplore);
+
+                var leafNode = true;
+                foreach (var pressureFrom in pressureGraph[toExplore].To) {
+                    if (currentBranchSet.Contains(pressureFrom)) {
+                        // Cycle, break it and backtrack
+                        pressureGraph[pressureFrom].From.Remove(toExplore);
+                        pressureGraph[toExplore].To.Remove(pressureFrom);
+
+                        removedPressures.Add(new Pressure<TItem>
+                        {
+                            To = { pressureFrom },
+                            From = { toExplore },
+                        });
+
+                        backtracking = true;
+                    }
+                    else if (!fullyCleared.Contains(pressureFrom)) {
+                        leafNode = false;
+                        explorationStack.Push(pressureFrom);
+                    }
+                }
+
+                // Leaf node, no cycle, let's backtrack
+                if (leafNode) {
+                    fullyCleared.Add(toExplore);
+                    backtracking = true;
+                }
+            }
+        }
+
+        // Start from the end
+        foreach (var (item, _) in pressureGraph.Where(kv => !fullyCleared.Contains(kv.Key) && !kv.Value.To.Any())) {
+            var currentBranchSet = new HashSet<TItem>();
+            var currentBranchStack = new Stack<TItem>();
+
+            var explorationStack = new Stack<TItem>();
+            explorationStack.Push(item);
+
+            // Depth first search
+            // When backtracking (reaching the end of a branch, no pressure from), clear the currentBranchSet because there were no cycles
+            var backtracking = false;
+            while (explorationStack.Any()) {
+                var toExplore = explorationStack.Pop();
+
+                if (backtracking) {
+                    while (!pressureGraph[currentBranchStack.Peek()].From.Contains(toExplore)) {
+                        fullyCleared.Add(currentBranchStack.Pop());
+                    }
+
+                    currentBranchSet = currentBranchStack.ToHashSet();
+                    backtracking = false;
+                }
+
+                currentBranchSet.Add(toExplore);
+                currentBranchStack.Push(toExplore);
+
+                var leafNode = true;
+                foreach (var pressureFrom in pressureGraph[toExplore].From) {
+                    if (currentBranchSet.Contains(pressureFrom)) {
+                        // Cycle, break it and backtrack
+                        pressureGraph[pressureFrom].To.Remove(toExplore);
+                        pressureGraph[toExplore].From.Remove(pressureFrom);
+
+                        removedPressures.Add(new Pressure<TItem>
+                        {
+                            From = { pressureFrom },
+                            To = { toExplore },
+                        });
+
+                        backtracking = true;
+                    }
+                    else if (!fullyCleared.Contains(pressureFrom)) {
+                        leafNode = false;
+                        explorationStack.Push(pressureFrom);
+                    }
+                }
+
+                // Leaf node, no cycle, let's backtrack
+                if (leafNode) {
+                    fullyCleared.Add(toExplore);
+                    backtracking = true;
+                }
+            }
+        }
+
+        // Clear remaining cycles
+        var remainingCycles = pressureGraph.Keys.Except(fullyCleared);
+        foreach (var item in remainingCycles) {
+            var currentBranchSet = new HashSet<TItem>();
+            var currentBranchStack = new Stack<TItem>();
+
+            var explorationStack = new Stack<TItem>();
+            explorationStack.Push(item);
+
+            // Depth first search
+            // When backtracking (reaching the end of a branch, no pressure from), clear the currentBranchSet because there were no cycles
+            var backtracking = false;
+            while (explorationStack.Any()) {
+                var toExplore = explorationStack.Pop();
+
+                if (backtracking) {
+                    while (!pressureGraph[currentBranchStack.Peek()].From.Contains(toExplore)) {
+                        fullyCleared.Add(currentBranchStack.Pop());
+                    }
+
+                    currentBranchSet = currentBranchStack.ToHashSet();
+                    backtracking = false;
+                }
+
+                currentBranchSet.Add(toExplore);
+                currentBranchStack.Push(toExplore);
+
+                var leafNode = true;
+                foreach (var pressureFrom in pressureGraph[toExplore].From) {
+                    if (currentBranchSet.Contains(pressureFrom)) {
+                        // Cycle, break it and backtrack
+                        pressureGraph[pressureFrom].To.Remove(toExplore);
+                        pressureGraph[toExplore].From.Remove(pressureFrom);
+
+                        removedPressures.Add(new Pressure<TItem>
+                        {
+                            From = { pressureFrom },
+                            To = { toExplore },
+                        });
+
+                        backtracking = true;
+                    }
+                    else if (!fullyCleared.Contains(pressureFrom)) {
+                        leafNode = false;
+                        explorationStack.Push(pressureFrom);
+                    }
+                }
+
+                // Leaf node, no cycle, let's backtrack
+                if (leafNode) {
+                    fullyCleared.Add(toExplore);
+                    backtracking = true;
+                }
+            }
+        }
+
+        return removedPressures;
+    }
+}

--- a/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/UnitsController.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/UnitsControl/UnitsController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.SneakAttackUnitsControl;
+using Bot.Managers.WarManagement.ArmySupervision.UnitsControl.StutterStepUnitsControl;
 
 namespace Bot.Managers.WarManagement.ArmySupervision.UnitsControl;
 

--- a/Bot/Managers/WarManagement/States/MidGame/MidGameBehaviour.cs
+++ b/Bot/Managers/WarManagement/States/MidGame/MidGameBehaviour.cs
@@ -92,7 +92,8 @@ public class MidGameBehaviour : IWarManagerBehaviour {
 
         CancelScouting();
 
-        var plannedUnitsAllocation = PlanUnitsAllocationToMaximizeImpact(GetAvailableUnits());
+        var availableUnits = GetAvailableUnits();
+        var plannedUnitsAllocation = PlanUnitsAllocationToMaximizeImpact(availableUnits);
         // TODO GD Reassign released units until they're all assigned?
         // ReleaseUnitsFromUnachievableGoals(plannedUnitsAllocation);
         PerformAllocation(plannedUnitsAllocation);

--- a/Bot/Managers/WarManagement/WarManagerAssigner.cs
+++ b/Bot/Managers/WarManagement/WarManagerAssigner.cs
@@ -8,5 +8,6 @@ public class WarManagerAssigner<T>: Assigner<T> {
     public override void Assign(Unit unit) {
         Logger.Debug("({0}) Assigned {1}", Client, unit);
         ChangelingTargetingModule.Install(unit);
+        AttackPriorityModule.Install(unit);
     }
 }

--- a/Bot/Managers/WarManagement/WarManagerReleaser.cs
+++ b/Bot/Managers/WarManagement/WarManagerReleaser.cs
@@ -8,5 +8,6 @@ public class WarManagerReleaser<T> : Releaser<T> {
     public override void Release(Unit unit) {
         Logger.Debug("({0}) Released {1}", Client, unit);
         UnitModule.Uninstall<ChangelingTargetingModule>(unit);
+        UnitModule.Uninstall<AttackPriorityModule>(unit);
     }
 }

--- a/Bot/UnitModules/AttackPriorityModule.cs
+++ b/Bot/UnitModules/AttackPriorityModule.cs
@@ -34,6 +34,10 @@ public class AttackPriorityModule: UnitModule {
             return;
         }
 
+        if (!_unit.IsReadyToAttack) {
+            return;
+        }
+
         if (_unit.Orders.All(order => order.AbilityId != Abilities.Attack)) {
             return;
         }


### PR DESCRIPTION
# Description
Stutter step worked, but wasn't as effective as expected.  
In this PR, we improved the algorithm and we now have turbo stutter stepping!

# What's new
- Stutter step now works a lot better, just have to look at it
- Added useful properties to `Unit` regarding weapons and enemy engagement
- Fixed bugs in `PressureGraph` where some cycles wouldn't be broken
  - Added tests to validate the fixes
- Moved the `PriorityAttackModule` to the `WarManager` from the `ArmySupervisor`
- Fixed a bug in `RegionalArmySupervisorState`s where we would hold references to dead units