### PR TITLE
Feature - Consider unit hit boxes when computing attack and sight reach

### DIFF
--- a/Bot/Managers/ScoutManagement/ScoutManager.cs
+++ b/Bot/Managers/ScoutManagement/ScoutManager.cs
@@ -77,8 +77,8 @@ public partial class ScoutManager : Manager {
         var antiGroundEnemies = enemyUnits.Where(enemyUnit => enemyUnit.CanHitGround).ToList();
         foreach (var unitToPreserve in unitsToPreserve) {
             var enemiesInVicinity = unitToPreserve.IsFlying
-                ? antiAirEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy, extraRange: -1.5f)).ToList()
-                : antiGroundEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy, extraRange: -1.5f)).ToList();
+                ? antiAirEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy)).ToList()
+                : antiGroundEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy)).ToList();
 
             if (enemiesInVicinity.Count > 0) {
                 var fleeVector = ComputeFleeUnitVector(unitToPreserve, enemiesInVicinity);

--- a/Bot/Managers/ScoutManagement/ScoutingSupervision/ScoutSupervisor.cs
+++ b/Bot/Managers/ScoutManagement/ScoutingSupervision/ScoutSupervisor.cs
@@ -27,8 +27,8 @@ public class ScoutSupervisor : Supervisor {
         var antiGroundEnemies = enemyUnits.Where(enemyUnit => enemyUnit.CanHitGround).ToList();
         foreach (var unitToPreserve in SupervisedUnits) {
             var enemiesInVicinity = unitToPreserve.IsFlying
-                ? antiAirEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy, extraRange: -1.5f)).ToList()
-                : antiGroundEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy, extraRange: -1.5f)).ToList();
+                ? antiAirEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy)).ToList()
+                : antiGroundEnemies.Where(enemy => unitToPreserve.IsInSightRangeOf(enemy)).ToList();
 
             if (enemiesInVicinity.Count > 0) {
                 var fleeVector = ComputeFleeUnitVector(unitToPreserve, enemiesInVicinity);

--- a/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorReleaser.cs
+++ b/Bot/Managers/WarManagement/ArmySupervision/ArmySupervisorReleaser.cs
@@ -1,6 +1,4 @@
-﻿using Bot.UnitModules;
-
-namespace Bot.Managers.WarManagement.ArmySupervision;
+﻿namespace Bot.Managers.WarManagement.ArmySupervision;
 
 public partial class ArmySupervisor {
     private class ArmySupervisorReleaser: IReleaser {

--- a/Bot/Unit.cs
+++ b/Bot/Unit.cs
@@ -517,24 +517,42 @@ public class Unit: ICanDie, IHavePosition {
         return false;
     }
 
-    public bool IsInAttackRangeOf(Unit enemy) {
-        return IsInAttackRangeOf(enemy.Position.ToVector2());
+    /// <summary>
+    /// Determines if the unit is in attack range of another unit based on their hit boxes and distance.
+    /// </summary>
+    /// <param name="otherUnit">The unit to attack</param>
+    /// <returns>True if the unit is in attack range of the other unit</returns>
+    public bool IsInAttackRangeOf(Unit otherUnit) {
+        return DistanceTo(otherUnit) <= otherUnit.Radius + MaxRange + Radius;
     }
 
-    public bool IsInAttackRangeOf(Unit enemy, float extraRange) {
-        return IsInAttackRangeOf(enemy.Position.ToVector2(), extraRange);
+    /// <summary>
+    /// Determines if the unit is in attack range of another unit based on their hit boxes and distance.
+    /// If you can, you should use IsInAttackRangeOf(Unit) instead because considering the other unit's hit box can make a big difference.
+    /// </summary>
+    /// <param name="position">The position to attack</param>
+    /// <returns>True if the unit is in attack range of the other unit</returns>
+    public bool IsInAttackRangeOf(Vector2 position) {
+        return DistanceTo(position) <= MaxRange + Radius;
     }
 
-    public bool IsInAttackRangeOf(Vector2 position, float extraRange = 0) {
-        return DistanceTo(position) <= MaxRange + extraRange;
+    /// <summary>
+    /// Determines if the unit is in sight range of another unit based on their hit boxes and distance.
+    /// </summary>
+    /// <param name="otherUnit">The unit to see</param>
+    /// <returns>True if the unit is in sight range of the other unit</returns>
+    public bool IsInSightRangeOf(Unit otherUnit) {
+        return DistanceTo(otherUnit) <= otherUnit.Radius + UnitTypeData.SightRange + Radius;
     }
 
-    public bool IsInSightRangeOf(Unit enemy, float extraRange) {
-        return IsInSightRangeOf(enemy.Position.ToVector2(), extraRange);
-    }
-
-    public bool IsInSightRangeOf(Vector2 position, float extraRange = 0) {
-        return DistanceTo(position) <= UnitTypeData.SightRange;
+    /// <summary>
+    /// Determines if the unit is in attack range of another unit based on their hit boxes and distance.
+    /// If you can, you should use IsInSightRangeOf(Unit) instead because considering the other unit's hit box can make a big difference.
+    /// </summary>
+    /// <param name="position">The position to attack</param>
+    /// <returns>True if the unit is in sight range of the other unit</returns>
+    public bool IsInSightRangeOf(Vector2 position) {
+        return DistanceTo(position) <= UnitTypeData.SightRange + Radius;
     }
 
     public bool HasOrders() {


### PR DESCRIPTION
# Description
Unit attack range is the distance between units hitboxes, not the distance between unit centers.
The same is true for sight range.

# What's new
- `IsInAttackRangeOf` now considers both unit radiuses
- `IsInSightRangeOf` now considers both unit radiuses

This fixes `StutterStep` pushing units forward even when they were all in range.
It probably fixes or improves other behaviours that I haven't noticed.