### PR TITLE
Bugfix - Fixed controller reliant test

### DIFF
--- a/Bot.Tests/BaseTestClass.cs
+++ b/Bot.Tests/BaseTestClass.cs
@@ -10,7 +10,7 @@ namespace Bot.Tests;
 // This is notably caused by the Controller and its friends WhoNeedUpdating
 [Collection("Sequential")]
 public class BaseTestClass :
-    IClassFixture<LoggerFixture>,
+    IClassFixture<NoLoggerFixture>,
     IClassFixture<KnowledgeBaseFixture>,
     IClassFixture<GraphicalDebuggerFixture>,
     IDisposable {

--- a/Bot.Tests/Fixtures/NoLoggerFixture.cs
+++ b/Bot.Tests/Fixtures/NoLoggerFixture.cs
@@ -1,8 +1,8 @@
 ﻿namespace Bot.Tests.Fixtures;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class LoggerFixture {
-    public LoggerFixture() {
+public class NoLoggerFixture {
+    public NoLoggerFixture() {
         Logger.Disable();
     }
 }

--- a/Bot.Tests/GameSense/RegionTracking/RegionsEvaluatorTests.cs
+++ b/Bot.Tests/GameSense/RegionTracking/RegionsEvaluatorTests.cs
@@ -1,11 +1,12 @@
 using System.Numerics;
 using Bot.GameSense.RegionTracking;
 using Bot.MapKnowledge;
+using Bot.Tests.Fixtures;
 
 namespace Bot.Tests.GameSense.RegionTracking;
 
 // TODO GD Test that it updates automatically and once per frame
-public class RegionsEvaluatorTests {
+public class RegionsEvaluatorTests : IClassFixture<NoLoggerFixture> {
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -125,12 +126,12 @@ public class RegionsEvaluatorTests {
         private readonly Dictionary<IRegion, float>? _evaluations;
 
         public TestRegionsEvaluator()
-            : base("test") {
+            : base("test", () => 1) {
             _evaluations = null;
         }
 
         public TestRegionsEvaluator(Dictionary<IRegion, float> evaluations)
-            : base("test") {
+            : base("test", () => 1) {
             _evaluations = evaluations;
         }
 

--- a/Bot.Tests/GameSense/RegionTracking/RegionsThreatEvaluatorTests.cs
+++ b/Bot.Tests/GameSense/RegionTracking/RegionsThreatEvaluatorTests.cs
@@ -1,11 +1,14 @@
 ﻿using System.Numerics;
 using Bot.GameSense.RegionTracking;
 using Bot.MapKnowledge;
+using Bot.Tests.Fixtures;
 using SC2APIProtocol;
 
 namespace Bot.Tests.GameSense.RegionTracking;
 
-public class RegionsThreatEvaluatorTests {
+public class RegionsThreatEvaluatorTests : IClassFixture<NoLoggerFixture> {
+    private static readonly Func<uint> GetCurrentFrame = () => 1;
+
     [Fact]
     public void GivenNoForcesAndNoValues_WhenUpdateEvaluations_ThenAllEvaluationsAreZero() {
         // Arrange
@@ -32,7 +35,7 @@ public class RegionsThreatEvaluatorTests {
 
         var enemyForceEvaluator = new TestRegionsForceEvaluator();
         var selfValueEvaluator = new TestRegionsValueEvaluator();
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -92,7 +95,7 @@ public class RegionsThreatEvaluatorTests {
             { region6, 0 },
         };
         var selfValueEvaluator = new TestRegionsValueEvaluator(valueEvaluations);
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -147,7 +150,7 @@ public class RegionsThreatEvaluatorTests {
         };
         var enemyForceEvaluator = new TestRegionsForceEvaluator(forceEvaluations);
         var selfValueEvaluator = new TestRegionsValueEvaluator();
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -207,7 +210,7 @@ public class RegionsThreatEvaluatorTests {
             { region6, 0 },
         };
         var selfValueEvaluator = new TestRegionsValueEvaluator(valueEvaluations);
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -266,7 +269,7 @@ public class RegionsThreatEvaluatorTests {
             { region6, 0 },
         };
         var selfValueEvaluator = new TestRegionsValueEvaluator(valueEvaluations);
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -325,7 +328,7 @@ public class RegionsThreatEvaluatorTests {
             { region6, 0 },
         };
         var selfValueEvaluator = new TestRegionsValueEvaluator(valueEvaluations);
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -384,7 +387,7 @@ public class RegionsThreatEvaluatorTests {
             { region6, 0 },
         };
         var selfValueEvaluator = new TestRegionsValueEvaluator(valueEvaluations);
-        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator);
+        var threatEvaluator = new RegionsThreatEvaluator(enemyForceEvaluator, selfValueEvaluator, GetCurrentFrame);
 
         enemyForceEvaluator.Init(regions);
         selfValueEvaluator.Init(regions);
@@ -403,12 +406,12 @@ public class RegionsThreatEvaluatorTests {
         private readonly Dictionary<IRegion, float>? _evaluations;
 
         public TestRegionsForceEvaluator()
-            : base(Alliance.Enemy) {
+            : base(Alliance.Enemy, GetCurrentFrame) {
             _evaluations = null;
         }
 
         public TestRegionsForceEvaluator(Dictionary<IRegion, float> evaluations)
-            : base(Alliance.Enemy) {
+            : base(Alliance.Enemy, GetCurrentFrame) {
             _evaluations = evaluations;
         }
 
@@ -421,12 +424,12 @@ public class RegionsThreatEvaluatorTests {
         private readonly Dictionary<IRegion, float>? _evaluations;
 
         public TestRegionsValueEvaluator()
-            : base(Alliance.Self) {
+            : base(Alliance.Self, GetCurrentFrame) {
             _evaluations = null;
         }
 
         public TestRegionsValueEvaluator(Dictionary<IRegion, float> evaluations)
-            : base(Alliance.Self) {
+            : base(Alliance.Self, GetCurrentFrame) {
             _evaluations = evaluations;
         }
 

--- a/Bot/GameSense/RegionTracking/RegionTracker.cs
+++ b/Bot/GameSense/RegionTracking/RegionTracker.cs
@@ -35,15 +35,16 @@ public class RegionTracker : INeedUpdating {
     };
 
     private RegionTracker() {
-        _regionForceEvaluators[Alliance.Self] = new RegionsForceEvaluator(Alliance.Self);
-        _regionForceEvaluators[Alliance.Enemy] = new RegionsForceEvaluator(Alliance.Enemy);
+        _regionForceEvaluators[Alliance.Self] = new RegionsForceEvaluator(Alliance.Self, () => Controller.Frame);
+        _regionForceEvaluators[Alliance.Enemy] = new RegionsForceEvaluator(Alliance.Enemy, () => Controller.Frame);
 
-        _regionValueEvaluators[Alliance.Self] = new RegionsValueEvaluator(Alliance.Self);
-        _regionValueEvaluators[Alliance.Enemy] = new RegionsValueEvaluator(Alliance.Enemy);
+        _regionValueEvaluators[Alliance.Self] = new RegionsValueEvaluator(Alliance.Self, () => Controller.Frame);
+        _regionValueEvaluators[Alliance.Enemy] = new RegionsValueEvaluator(Alliance.Enemy, () => Controller.Frame);
 
         _regionThreatEvaluators[Alliance.Enemy] = new RegionsThreatEvaluator(
             _regionForceEvaluators[Alliance.Enemy],
-            _regionValueEvaluators[Alliance.Self]
+            _regionValueEvaluators[Alliance.Self],
+            () => Controller.Frame
         );
     }
 

--- a/Bot/GameSense/RegionTracking/RegionsForceEvaluator.cs
+++ b/Bot/GameSense/RegionTracking/RegionsForceEvaluator.cs
@@ -14,7 +14,7 @@ public class RegionsForceEvaluator : RegionsEvaluator {
     private static readonly ulong HalfLife = TimeUtils.SecsToFrames(120);
     private static readonly double ExponentialDecayConstant = Math.Log(2) / HalfLife;
 
-    public RegionsForceEvaluator(Alliance alliance) : base("force") {
+    public RegionsForceEvaluator(Alliance alliance, Func<uint> getCurrentFrame) : base("force", getCurrentFrame) {
         _alliance = alliance;
     }
 

--- a/Bot/GameSense/RegionTracking/RegionsThreatEvaluator.cs
+++ b/Bot/GameSense/RegionTracking/RegionsThreatEvaluator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bot.ExtensionMethods;
 using Bot.MapKnowledge;
@@ -9,8 +10,8 @@ public class RegionsThreatEvaluator : RegionsEvaluator {
     private readonly IRegionsEvaluator _forceEvaluator;
     private readonly IRegionsEvaluator _opponentValueEvaluator;
 
-    public RegionsThreatEvaluator(RegionsForceEvaluator forceEvaluator, RegionsValueEvaluator opponentValueEvaluator)
-        : base("threat", new List<IRegionsEvaluator> { forceEvaluator, opponentValueEvaluator }) {
+    public RegionsThreatEvaluator(RegionsForceEvaluator forceEvaluator, RegionsValueEvaluator opponentValueEvaluator, Func<uint> getCurrentFrame)
+        : base("threat", getCurrentFrame, new List<IRegionsEvaluator> { forceEvaluator, opponentValueEvaluator }) {
         _forceEvaluator = forceEvaluator;
         _opponentValueEvaluator = opponentValueEvaluator;
     }

--- a/Bot/GameSense/RegionTracking/RegionsValueEvaluator.cs
+++ b/Bot/GameSense/RegionTracking/RegionsValueEvaluator.cs
@@ -14,7 +14,7 @@ public class RegionsValueEvaluator : RegionsEvaluator {
     private static readonly ulong HalfLife = TimeUtils.SecsToFrames(240);
     private static readonly double ExponentialDecayConstant = Math.Log(2) / HalfLife;
 
-    public RegionsValueEvaluator(Alliance alliance) : base("value") {
+    public RegionsValueEvaluator(Alliance alliance, Func<uint> getCurrentFrame) : base("value", getCurrentFrame) {
         _alliance = alliance;
     }
 

--- a/Bot/GameSense/UnitsTracker.cs
+++ b/Bot/GameSense/UnitsTracker.cs
@@ -116,7 +116,7 @@ public class UnitsTracker: INeedUpdating {
             .Select(unit => (unit.Name, unit.UnitType))
             .ToList();
 
-        Logger.Metric("Unknown Neutral Units: [{0}]", string.Join(", ", unknownNeutralUnits));
+        Logger.Metric($"Unknown Neutral Units: [{string.Join(", ", unknownNeutralUnits)}]");
     }
 
     private static void HandleNewUnit(SC2APIProtocol.Unit newRawUnit, ulong currentFrame) {


### PR DESCRIPTION
# Description
The `RegionEvalutatorTests` were reliant on the `Controller.Frame` to work properly, but the controller fixture wasn't being used.
This caused race conditions that were only visible in release mode, especially on the CI.

# What's new
- The "frame clock" is injected in the `RegionEvalutator` as a functor to follow the DI spirit of this class (and the upcoming classes)
- Disabled the logger on some test classes because it was producing unnecessary logs