### PR TITLE
Bugfix - Avoid targeting cloaked units

### DIFF
--- a/Bot/Managers/WarManagement/States/MidGame/MidGameBehaviour.cs
+++ b/Bot/Managers/WarManagement/States/MidGame/MidGameBehaviour.cs
@@ -251,6 +251,7 @@ public class MidGameBehaviour : IWarManagerBehaviour {
         var regionsToAvoid = RegionAnalyzer.Regions.Except(reachableRegions).ToHashSet();
 
         return reachableRegions.MaxBy(reachableRegion => {
+            // TODO GD This doesn't take into account if the unit can address the threat (grounds vs flying, cloaked, etc)
             var regionThreat = RegionTracker.GetThreat(reachableRegion, Alliance.Enemy);
             var regionValue = RegionTracker.GetValue(reachableRegion, Alliance.Enemy);
 

--- a/Bot/Unit.cs
+++ b/Bot/Unit.cs
@@ -537,6 +537,10 @@ public class Unit: ICanDie, IHavePosition {
     /// <param name="otherUnit">The unit to attack</param>
     /// <returns>True if the unit has the proper weapons to attack the other unit.</returns>
     public bool CanAttack(Unit otherUnit) {
+        if (otherUnit.IsCloaked) {
+            return false;
+        }
+
         if (otherUnit.IsFlying) {
             return CanHitAir;
         }


### PR DESCRIPTION
Just a small patch to try and avoid targeting cloaked units.
The real solution to this problem is going to require more changes.