### PR TITLE
Feature/48 - Improve disengage state transition

### DIFF
--- a/Sajuuk/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/DisengageState.cs
+++ b/Sajuuk/Managers/WarManagement/ArmySupervision/RegionalArmySupervision/DisengageState.cs
@@ -87,7 +87,7 @@ public class DisengageState : RegionalArmySupervisionState {
         }
 
         return supervisedUnits
-            .Where(unit => _regionsEvaluationsTracker.GetForce(unit.GetRegion(), Alliance.Enemy) <= 0)
+            .Where(unit => _regionsEvaluationsTracker.GetForce(unit.GetRegion(), Alliance.Enemy) <= 0 || !enemyArmy.Any(enemy => enemy.IsInSightRangeOf(unit)))
             .ToHashSet();
     }
 


### PR DESCRIPTION
## Issue
fixes https://github.com/Guillaume-Docquier/Sajuuk-SC2/issues/48

## Description
The disengage state would only transition out if all the army was out of the dangerous region, but it also tries to bring reinforcements close to it as well. This resulted in the army not being able to get out of danger completely.

## What's new
- Units are now considered safe if no enemy can see them, even if they are in a dangerous region.